### PR TITLE
Fix tonumber overflow behavior

### DIFF
--- a/test/number_test.dart
+++ b/test/number_test.dart
@@ -24,7 +24,7 @@ void main() {
       expect(LuaNumberParser.parse('0XFB'), equals(251));
       expect(
         LuaNumberParser.parse('0x8000000000000000'),
-        allOf(isA<BigInt>(), equals(BigInt.parse('9223372036854775808'))),
+        equals(-9223372036854775808),
       );
     });
 
@@ -36,8 +36,8 @@ void main() {
 
     test('big decimal promotion', () {
       final value = LuaNumberParser.parse('12345678901234567890');
-      expect(value, isA<BigInt>());
-      expect(value, equals(BigInt.parse('12345678901234567890')));
+      expect(value, isA<double>());
+      expect(value, equals(double.parse('12345678901234567890')));
     });
 
     test('math.lua special formats', () {


### PR DESCRIPTION
## Summary
- handle decimal integer overflow in `LuaNumberParser`
- wrap large hexadecimal and binary integers to 64-bit
- update number tests to match Lua behavior

## Testing
- `dart test`


------
https://chatgpt.com/codex/tasks/task_e_686324d874b0833189b382f93f5ca1f0