### PR TITLE
Fix goto label scoping

### DIFF
--- a/lib/src/interpreter/function.dart
+++ b/lib/src/interpreter/function.dart
@@ -219,8 +219,12 @@ mixin InterpreterFunctionMixin on AstVisitor<Object?> {
         );
 
         // Execute the function body in the new environment
-        for (final stmt in node.body) {
-          result = await stmt.accept(this);
+        if (this is Interpreter) {
+          result = await (this as Interpreter)._executeStatements(node.body);
+        } else {
+          for (final stmt in node.body) {
+            result = await stmt.accept(this);
+          }
         }
       } on ReturnException catch (e) {
         result = e.value;


### PR DESCRIPTION
## Summary
- handle goto labels per block rather than globally
- allow functions and blocks to execute statements with local label resolution
- add tests covering backward jumps and label scoping

## Testing
- `dart analyze`
- `dart test`

------
https://chatgpt.com/codex/tasks/task_e_68644399f0c48331bdeaba1f2758133a