### PR TITLE
Add goto repeat loop test

### DIFF
--- a/test/interpreter/statements/goto_loop_exit_test.dart
+++ b/test/interpreter/statements/goto_loop_exit_test.dart
@@ -1,0 +1,37 @@
+import 'package:lualike/testing.dart';
+
+void main() {
+  group('Goto with loops', () {
+    test('goto exits a for loop to outer label', () async {
+      var program = <AstNode>[
+        LocalDeclaration([Identifier('i')], [], [NumberLiteral(0)]),
+        Label(Identifier('again')),
+        ForLoop(
+          Identifier('j'),
+          NumberLiteral(1),
+          NumberLiteral(10),
+          NumberLiteral(1),
+          [
+            Assignment(
+              [Identifier('i')],
+              [BinaryExpression(Identifier('i'), '+', NumberLiteral(1))],
+            ),
+            IfStatement(
+              BinaryExpression(Identifier('i'), '>=', NumberLiteral(5)),
+              [],
+              [Goto(Identifier('done'))],
+              [],
+            ),
+          ],
+        ),
+        Goto(Identifier('again')),
+        Label(Identifier('done')),
+        ExpressionStatement(Identifier('i')),
+      ];
+
+      var vm = Interpreter();
+      await vm.run(program);
+      expect(vm.globals.get('i'), equals(Value(5)));
+    });
+  });
+}

--- a/test/interpreter/statements/goto_repeat_loop_test.dart
+++ b/test/interpreter/statements/goto_repeat_loop_test.dart
@@ -1,0 +1,35 @@
+import 'package:lualike/testing.dart';
+
+void main() {
+  group('Goto with repeated loops', () {
+    test('goto repeats a for loop until condition met', () async {
+      var program = <AstNode>[
+        LocalDeclaration([Identifier('i')], [], [NumberLiteral(0)]),
+        Label(Identifier('doagain')),
+        ForLoop(
+          Identifier('j'),
+          NumberLiteral(1),
+          NumberLiteral(2),
+          NumberLiteral(1),
+          [
+            Assignment(
+              [Identifier('i')],
+              [BinaryExpression(Identifier('i'), '+', NumberLiteral(1))],
+            ),
+          ],
+        ),
+        IfStatement(
+          BinaryExpression(Identifier('i'), '<', NumberLiteral(5)),
+          [],
+          [Goto(Identifier('doagain'))],
+          [],
+        ),
+        ExpressionStatement(Identifier('i')),
+      ];
+
+      var vm = Interpreter();
+      await vm.run(program);
+      expect(vm.globals.get('i'), equals(Value(6)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a repeat loop test for goto to ensure loops can restart correctly

## Testing
- `dart fix --apply`
- `dart format .`
- `dart test`


------
https://chatgpt.com/codex/tasks/task_e_6864510c5f2c833194d5c68f3309ab4d