### PR TITLE
Add random test scripts and clean logger

### DIFF
--- a/lib/src/interpreter/interpreter.dart
+++ b/lib/src/interpreter/interpreter.dart
@@ -484,6 +484,7 @@ class Interpreter extends AstVisitor<Object?>
       await _executeStatements(program);
     } on GotoException catch (e) {
       // Report undefined label with helpful message
+      Logger.warning('Undefined label: ${e.label}', category: 'Interpreter');
       throw GotoException('Undefined label: ${e.label}');
     }
 
@@ -514,7 +515,6 @@ class Interpreter extends AstVisitor<Object?>
         result = await node.accept(this);
         index++;
       } on GotoException catch (e) {
-        Logger.warning('Undefined label: ${e.label}', category: 'Interpreter');
         if (!labelMap.containsKey(e.label)) {
           // Propagate to outer scope for resolution
           throw GotoException(e.label);

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -15,7 +15,6 @@ class Logger {
   static bool enabled = false;
 
   static final Map<String, pkg_logging.Logger> _categoryLoggers = {};
-  static pkg_logging.Level _defaultLevel = pkg_logging.Level.INFO;
 
   /// Optional filters for log output
   static String? logCategoryFilter;
@@ -36,7 +35,6 @@ class Logger {
   static void initialize({
     pkg_logging.Level defaultLevel = pkg_logging.Level.INFO,
   }) {
-    _defaultLevel = defaultLevel;
     pkg_logging.Logger.root.level = defaultLevel;
     pkg_logging.Logger.root.onRecord.listen((record) {
       // Filter by category if set
@@ -72,7 +70,6 @@ class Logger {
 
   /// Set the default log level for all loggers.
   static void setDefaultLevel(pkg_logging.Level level) {
-    _defaultLevel = level;
     pkg_logging.Logger.root.level = level;
   }
 
@@ -116,7 +113,7 @@ class Logger {
   }) {
     final errorDetails = error != null ? ' - $error' : '';
     if (error is LuaError) {
-      final errorMessage = '${error.formatError()}';
+      final errorMessage = error.formatError();
       _getLogger(category).severe(errorMessage, error, trace);
       if (luaStackTrace != null) {
         _getLogger(category).severe(luaStackTrace.format());

--- a/luascripts/random_float_test.lua
+++ b/luascripts/random_float_test.lua
@@ -1,0 +1,36 @@
+local random, max, min = math.random, math.max, math.min
+local function eq(a, b, limit)
+  limit = limit or 1e-5
+  return a == b or math.abs(a-b) <= limit
+end
+local randbits = math.min(53, 64)
+local mult = 2^randbits
+local counts = {}
+for i = 1, randbits do counts[i] = 0 end
+local up = -math.huge
+local low = math.huge
+local rounds = 10
+local totalrounds = 0
+::doagain::
+print('loop start', totalrounds)
+for i = 0, rounds do
+  local t = random()
+  up = max(up, t)
+  low = min(low, t)
+  local bit = i % randbits
+  if (t * 2^bit) % 1 >= 0.5 then
+    counts[bit + 1] = counts[bit + 1] + 1
+  end
+end
+totalrounds = totalrounds + rounds
+if not (eq(up, 1, 0.001) and eq(low, 0, 0.001)) then
+  goto doagain
+end
+print('passed range check')
+local expected = (totalrounds / randbits / 2)
+for i = 1, randbits do
+  if not (math.abs(counts[i] - expected) < expected * 0.10) then
+    goto doagain
+  end
+end
+print('finished after', totalrounds)

--- a/luascripts/random_int_test.lua
+++ b/luascripts/random_int_test.lua
@@ -1,0 +1,32 @@
+local random, max, min = math.random, math.max, math.min
+local intbits = math.floor(math.log(math.maxinteger,2)+0.5)+1
+local maxint = math.maxinteger
+local minint = math.mininteger
+local counts = {}
+for i = 1, intbits do counts[i] = 0 end
+local up = 0
+local low = 0
+local rounds = 10
+local totalrounds = 0
+::doagain::
+print('loop start', totalrounds)
+for i=0, rounds do
+  local t = random(0)
+  up = max(up, t)
+  low = min(low, t)
+  local bit = i % intbits
+  counts[bit+1] = counts[bit+1] + ((t >> bit) & 1)
+end
+totalrounds = totalrounds + rounds
+local lim = maxint >> 10
+if not (maxint - up < lim and low - minint < lim) then
+  goto doagain
+end
+print('passed range check')
+local expected = totalrounds / intbits / 2
+for i=1,intbits do
+  if not (math.abs(counts[i]-expected) < expected*0.10) then
+    goto doagain
+  end
+end
+print('finished after', totalrounds)

--- a/test/interpreter/statements/goto_outer_from_loop_test.dart
+++ b/test/interpreter/statements/goto_outer_from_loop_test.dart
@@ -1,0 +1,35 @@
+import 'package:lualike/testing.dart';
+
+void main() {
+  group('Goto to outer label from inside loop', () {
+    test('goto jumps from loop to outer label', () async {
+      var program = <AstNode>[
+        LocalDeclaration([Identifier('i')], [], [NumberLiteral(0)]),
+        Label(Identifier('doagain')),
+        ForLoop(
+          Identifier('j'),
+          NumberLiteral(1),
+          NumberLiteral(5),
+          NumberLiteral(1),
+          [
+            Assignment(
+              [Identifier('i')],
+              [BinaryExpression(Identifier('i'), '+', NumberLiteral(1))],
+            ),
+            IfStatement(
+              BinaryExpression(Identifier('i'), '<', NumberLiteral(3)),
+              [],
+              [Goto(Identifier('doagain'))],
+              [],
+            ),
+          ],
+        ),
+        ExpressionStatement(Identifier('i')),
+      ];
+
+      var vm = Interpreter();
+      await vm.run(program);
+      expect(vm.globals.get('i'), equals(Value(7)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- remove unused `_defaultLevel` from logger
- add `random_float_test.lua` and `random_int_test.lua` scripts to isolate long-running loops

## Testing
- `dart analyze`
- `dart test`


------
https://chatgpt.com/codex/tasks/task_e_68647915d4f08331a685f736be65dcf1