### PR TITLE
Fix finalizer registration and protect stdout

### DIFF
--- a/lib/src/gc/gc.dart
+++ b/lib/src/gc/gc.dart
@@ -29,7 +29,7 @@ abstract class GCObject {
   /// Similar to Lua's finalizers, this method is called when an object
   /// is about to be collected, allowing it to release any external resources.
   void free() {
-    print('[GC] GCObject.free() called for ${runtimeType} ${hashCode}');
+    print('[GC] GCObject.free() called for $runtimeType $hashCode');
     // By default, nothing needs to be done.
   }
 }

--- a/lib/src/gc/generational_gc.dart
+++ b/lib/src/gc/generational_gc.dart
@@ -46,10 +46,12 @@ class GenerationalGCManager {
 
   /// Singleton instance of the garbage collector.
   static late GenerationalGCManager instance;
+  static bool isInitialized = false;
 
   /// Initializes the garbage collector with a reference to the interpreter.
   static void initialize(Interpreter interpreter) {
     instance = GenerationalGCManager._(interpreter);
+    isInitialized = true;
   }
 
   // Private constructor

--- a/lib/src/io/io_device.dart
+++ b/lib/src/io/io_device.dart
@@ -497,7 +497,8 @@ class StdoutDevice extends BaseIODevice {
 
   @override
   Future<void> close() async {
-    isClosed = true;
+    // Do not actually close stdout; keep it available for the entire
+    // interpreter lifecycle.
   }
 
   @override

--- a/lib/src/stdlib/lib_base.dart
+++ b/lib/src/stdlib/lib_base.dart
@@ -7,7 +7,6 @@ import 'package:lualike/src/bytecode/vm.dart';
 import 'package:lualike/src/const_checker.dart';
 import 'package:lualike/src/coroutine.dart' show Coroutine;
 import 'package:lualike/src/stdlib/lib_io.dart';
-import 'metatables.dart';
 import 'package:path/path.dart' as path;
 
 /// Built-in function to retrieve the metatable of a value.

--- a/lib/src/value.dart
+++ b/lib/src/value.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:lualike/lualike.dart';
 import 'package:lualike/src/gc/gc.dart';
+import 'package:lualike/src/gc/generational_gc.dart';
 import 'package:lualike/src/stdlib/metatables.dart';
 
 import 'package:lualike/src/upvalue.dart';
@@ -93,6 +94,10 @@ class Value extends Object implements Map<String, dynamic>, GCObject {
       MetaTable().applyDefaultMetatable(this);
     } else {
       this.metatable = metatable;
+    }
+
+    if (GenerationalGCManager.isInitialized) {
+      GenerationalGCManager.instance.register(this);
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure GC has an initialization flag
- register new `Value` objects with the GC only when the manager is initialized
- avoid closing stdout when temporary `Value` wrappers are finalized

## Testing
- `dart analyze`
- `dart test`


------
https://chatgpt.com/codex/tasks/task_e_6872a7eafc208331bc57d1ddeb027a5b