### PR TITLE
Improve number metatable support

### DIFF
--- a/lib/src/interpreter/table.dart
+++ b/lib/src/interpreter/table.dart
@@ -116,6 +116,15 @@ mixin InterpreterTableMixin on AstVisitor<Object?> {
     );
 
     if (tableVal.raw is! Map) {
+      final indexMeta = tableVal.getMetamethod('__index');
+      if (indexMeta != null) {
+        Logger.debug('DEBUG: Calling __index metamethod for non-table field');
+        final result = await tableVal.callMetamethodAsync('__index', [
+          tableVal,
+          indexVal,
+        ]);
+        return result;
+      }
       if (tableVal.raw == null) {
         throw LuaError.typeError('attempt to index a nil value');
       }
@@ -201,6 +210,14 @@ mixin InterpreterTableMixin on AstVisitor<Object?> {
     );
 
     if (tableVal.raw is! Map) {
+      final indexMeta = tableVal.getMetamethod('__index');
+      if (indexMeta != null) {
+        final result = await tableVal.callMetamethodAsync('__index', [
+          tableVal,
+          indexVal,
+        ]);
+        return result;
+      }
       if (tableVal.raw == null) {
         throw LuaError.typeError('attempt to index a nil value');
       }

--- a/lib/src/stdlib/lib_debug.dart
+++ b/lib/src/stdlib/lib_debug.dart
@@ -1,9 +1,9 @@
 import 'dart:io';
 
-import 'package:lualike/src/bytecode/vm.dart';
 import 'package:lualike/lualike.dart';
-import 'package:lualike/src/stdlib/metatables.dart';
+import 'package:lualike/src/bytecode/vm.dart';
 import 'package:lualike/src/coroutine.dart';
+import 'package:lualike/src/stdlib/metatables.dart';
 
 class DebugLib {
   static final Map<String, BuiltinFunction> functions = {
@@ -247,17 +247,18 @@ class _SetMetatable implements BuiltinFunction {
     final value = args[0] as Value;
     final meta = args[1] as Value;
     if (value.raw is! Map) {
+      final type = _typeOf(value.raw);
       if (meta.raw == null) {
-        MetaTable().registerDefaultMetatable(
-          _typeOf(value.raw),
-          ValueClass.create({}),
-        );
+        MetaTable().registerDefaultMetatable(type, null);
         return Value(true);
       }
       if (meta.raw is Map) {
         MetaTable().registerDefaultMetatable(
-          _typeOf(value.raw),
-          ValueClass.create((meta.raw as Map).cast()),
+          type,
+          ValueClass.create(
+            Map.castFrom<dynamic, dynamic, String, dynamic>(meta.raw as Map),
+          ),
+          meta,
         );
         return Value(true);
       }

--- a/test/stdlib/debug_setmetatable_test.dart
+++ b/test/stdlib/debug_setmetatable_test.dart
@@ -1,0 +1,26 @@
+import 'package:lualike/testing.dart';
+
+void main() {
+  group('debug.setmetatable', () {
+    late LuaLike bridge;
+
+    setUp(() {
+      bridge = LuaLike();
+    });
+
+    test('number metatable registration and removal', () async {
+      await bridge.runCode('''
+        mt = {__index = function(a,b) return a+b end}
+        debug.setmetatable(10, mt)
+        check1 = getmetatable(-2) == mt
+        res = (10)[3]
+        debug.setmetatable(23, nil)
+        check2 = getmetatable(-2) == nil
+      ''');
+
+      expect((bridge.getGlobal('check1') as Value).raw, isTrue);
+      expect((bridge.getGlobal('res') as Value).raw, equals(13));
+      expect((bridge.getGlobal('check2') as Value).raw, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- preserve references for default metatables so `getmetatable` returns the same object
- allow registering or clearing defaults via `debug.setmetatable`
- handle `__index` on non-table values during field and index access
- test registering and removing a default number metatable

## Testing
- `dart analyze`
- `dart test`
- `dart run bin/main.dart luascripts/test/events.lua`

------
https://chatgpt.com/codex/tasks/task_e_68737dbc62f083318aa4c241140e637c