### PR TITLE
Fix script path in spans for modules

### DIFF
--- a/lib/src/call_stack.dart
+++ b/lib/src/call_stack.dart
@@ -18,12 +18,8 @@ class CallFrame {
   /// Creates a LuaStackFrame from this call frame.
   LuaStackFrame toLuaStackFrame() {
     return callNode != null
-        ? LuaStackFrame.fromNode(
-            callNode!,
-            functionName,
-            scriptPath: scriptPath,
-          )
-        : LuaStackFrame(functionName, scriptPath: scriptPath);
+        ? LuaStackFrame.fromNode(callNode!, functionName)
+        : LuaStackFrame(functionName);
   }
 }
 

--- a/lib/src/interpreter/interpreter.dart
+++ b/lib/src/interpreter/interpreter.dart
@@ -380,14 +380,8 @@ class Interpreter extends AstVisitor<Object?>
           }
 
           if (!isDuplicate) {
-            // Get the script path from the call stack
-            final scriptPath = callStack.scriptPath;
             recentTrace.add(
-              LuaStackFrame.fromNode(
-                frame.callNode!,
-                frame.functionName,
-                scriptPath: scriptPath,
-              ),
+              LuaStackFrame.fromNode(frame.callNode!, frame.functionName),
             );
           }
         }
@@ -504,6 +498,7 @@ class Interpreter extends AstVisitor<Object?>
     );
 
     // Set the script path in the call stack if available
+    final prevScriptPath = callStack.scriptPath;
     final scriptPathValue = globals.get('_SCRIPT_PATH');
     if (scriptPathValue is Value && scriptPathValue.raw != null) {
       String scriptPath = scriptPathValue.raw.toString();
@@ -536,6 +531,11 @@ class Interpreter extends AstVisitor<Object?>
     }
 
     Logger.info('Program finished', category: 'Interpreter');
+
+    // Restore previous script path
+    callStack.setScriptPath(prevScriptPath);
+    currentScriptPath = prevScriptPath;
+
     return evalStack.isEmpty ? null : evalStack.peek();
   }
 

--- a/lib/src/parse.dart
+++ b/lib/src/parse.dart
@@ -2,5 +2,13 @@ import 'ast.dart';
 import 'parsers/lua.dart' as lua;
 
 Program parse(String source, {Object? url}) {
-  return lua.parse(source);
+  Uri? uri;
+  if (url != null) {
+    if (url is Uri) {
+      uri = url;
+    } else {
+      uri = Uri.file(url.toString());
+    }
+  }
+  return lua.parse(source, url: uri);
 }

--- a/lib/src/stdlib/lib_base.dart
+++ b/lib/src/stdlib/lib_base.dart
@@ -638,7 +638,7 @@ class LoadFunction implements BuiltinFunction {
     }
 
     try {
-      final ast = parse(source);
+      final ast = parse(source, url: chunkname);
 
       // Check for const variable assignment errors
       final constChecker = ConstChecker();
@@ -714,7 +714,7 @@ class DoFileFunction implements BuiltinFunction {
 
     try {
       // Parse content into AST
-      final ast = parse(source);
+      final ast = parse(source, url: filename);
 
       // Execute in current VM context
       final result = vm.run(ast.statements);
@@ -784,7 +784,7 @@ class LoadfileFunction implements BuiltinFunction {
               return utf8.decode(bytes);
             }();
 
-      final ast = parse(source);
+      final ast = parse(source, url: filename);
       return Value((List<Object?> callArgs) {
         final vm = Interpreter();
         try {
@@ -1479,7 +1479,7 @@ class RequireFunction implements BuiltinFunction {
           category: 'Require',
         );
         // Parse the module code
-        final ast = parse(source);
+        final ast = parse(source, url: modulePathStr);
 
         // Create a new environment for the module
         final moduleEnv = Environment(parent: vm.globals, interpreter: vm);

--- a/lib/src/stdlib/lib_package.dart
+++ b/lib/src/stdlib/lib_package.dart
@@ -217,7 +217,7 @@ class _LuaLoader implements BuiltinFunction {
           try {
             // Parse the module code
             print("DEBUG: Parsing module code");
-            final ast = parse(source);
+            final ast = parse(source, url: modulePath);
             print("DEBUG: Module code parsed successfully");
 
             // Create a new environment for the module

--- a/test/interpreter/multi_file_stack_trace_test.dart
+++ b/test/interpreter/multi_file_stack_trace_test.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:lualike/testing.dart';
+
+void main() {
+  group('Stack trace across files', () {
+    test('reports correct file names', () async {
+      final bridge = LuaLike();
+
+      bridge.vm.fileManager.registerVirtualFile('mod.lua', '''
+local M = {}
+function M.trigger()
+  assert(false, 'fail')
+end
+return M
+''');
+
+      final mainSource = '''
+local mod = require("mod")
+local function run()
+  mod.trigger()
+end
+run()
+''';
+
+      final buffer = StringBuffer();
+
+      await runZoned(
+        () async {
+          try {
+            await bridge.runCode(mainSource, scriptPath: 'main.lua');
+            fail('expected error');
+          } catch (_) {}
+        },
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, msg) {
+            buffer.writeln(msg);
+          },
+        ),
+      );
+
+      final output = buffer.toString();
+      expect(output, contains('mod:3'));
+      expect(output, contains('main.lua:3'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- forward the `url` to the parser so nodes know which file they came from
- drop cached scriptPath use in `CallFrame` and error reporting
- include the filename when loading modules and files
- add a regression test covering multi-file stack traces

## Testing
- `dart analyze`
- `dart test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6873dfd6ebc48331abdab50c44e03258