### PR TITLE
Fix string packing tests & alignment

### DIFF
--- a/test/parsers/binary_format_test.dart
+++ b/test/parsers/binary_format_test.dart
@@ -68,8 +68,11 @@ void main() {
     test('invalid option: Q', () {
       expect(() => BinaryFormatParser.parse('Q'), throwsA(isA<LuaError>()));
     });
-    test('I without number (error)', () {
-      expect(() => BinaryFormatParser.parse('I'), throwsA(isA<LuaError>()));
+    test('I without number', () {
+      final options = BinaryFormatParser.parse('I');
+      expect(options.length, 1);
+      expect(options[0].type, 'I');
+      expect(options[0].size, isNull);
     });
     test('multiple: I4c10z', () {
       final options = BinaryFormatParser.parse('I4c10z');

--- a/test/stdlib/string_test.dart
+++ b/test/stdlib/string_test.dart
@@ -671,9 +671,9 @@ void main() {
             local a3, pos3 = string.unpack("c6", s3)
           ''');
 
-          expect((bridge.getGlobal('a1') as Value).raw, equals("hÃ©llo"));
-          expect((bridge.getGlobal('a2') as Value).raw, equals("ä¸ç"));
-          expect((bridge.getGlobal('a3') as Value).raw, equals("hÃ©llo"));
+          expect((bridge.getGlobal('a1') as Value).raw, equals("héllo"));
+          expect((bridge.getGlobal('a2') as Value).raw, equals("世界"));
+          expect((bridge.getGlobal('a3') as Value).raw, equals("héllo"));
         });
       });
 
@@ -716,7 +716,7 @@ void main() {
         ); // 1+3 pad+4
         expect(
           (bridge.getGlobal('size_padded') as Value).raw,
-          equals(5),
+          equals(8),
         ); // 1+3 pad+4 (no alignment for x)
       });
 


### PR DESCRIPTION
## Summary
- fix tests for unicode string packing
- correct packsize test values
- parse unsigned format without number
- implement alignment logic in `string.packsize`
- decode UTF-8 strings correctly when unpacking

## Testing
- `dart format lib/src/stdlib/lib_string.dart test/stdlib/string_test.dart test/parsers/binary_format_test.dart`
- `dart fix --apply`
- `dart analyze`
- `dart test`

------
https://chatgpt.com/codex/tasks/task_e_6873eb49baa48331b8329265363f2367