### PR TITLE
Goto support

### DIFF
--- a/pkgs/lualike/lib/src/goto_validator.dart
+++ b/pkgs/lualike/lib/src/goto_validator.dart
@@ -1,0 +1,471 @@
+import 'package:source_span/source_span.dart';
+
+import 'ast.dart';
+
+/// Validates goto/label usage in a parsed chunk.
+///
+/// Mirrors Lua's compile-time checks to ensure we reject invalid
+/// goto statements during `load()` rather than at runtime.
+class GotoLabelValidator {
+  /// Checks the provided [program] for goto/label rule violations.
+  ///
+  /// Returns an error string if a violation is found, or `null` when
+  /// the AST complies with Lua's rules.
+  String? checkGotoLabelViolations(Program program) {
+    final state = _ValidatorState();
+    return state.validateChunk(program.statements);
+  }
+
+  /// Validates a nested [FunctionBody]. Used when function literals or
+  /// declarations appear inside a chunk.
+  String? checkFunctionBody(FunctionBody body) {
+    final state = _ValidatorState();
+    return state.validateChunk(
+      body.body,
+      parameters: body.parameters ?? const <Identifier>[],
+    );
+  }
+}
+
+class _ValidatorState {
+  final List<_LocalInfo> _activeLocals = [];
+
+  String? validateChunk(
+    List<AstNode> statements, {
+    List<Identifier> parameters = const <Identifier>[],
+  }) {
+    final root = _BlockContext(
+      parent: null,
+      depth: 0,
+      activeLocalStartIndex: _activeLocals.length,
+    );
+
+    for (final param in parameters) {
+      _addLocal(param.name, param.span, root);
+    }
+
+    final error = _processBlock(statements, root);
+    if (error != null) {
+      return error;
+    }
+
+    final finishError = _finishBlock(root, isRoot: true);
+    if (finishError != null) {
+      return finishError;
+    }
+
+    return null;
+  }
+
+  String? _processBlock(List<AstNode> statements, _BlockContext block) {
+    for (final stmt in statements) {
+      final error = _visitStatement(stmt, block);
+      if (error != null) {
+        return error;
+      }
+    }
+    return null;
+  }
+
+  String? _finishBlock(_BlockContext block, {required bool isRoot}) {
+    if (_activeLocals.length > block.activeLocalStartIndex) {
+      _activeLocals.removeRange(
+        block.activeLocalStartIndex,
+        _activeLocals.length,
+      );
+    }
+
+    final parent = block.parent;
+    if (parent != null) {
+      for (final pending in block.pendingGotos) {
+        if (pending.activeLocalCount > _activeLocals.length) {
+          pending.activeLocalCount = _activeLocals.length;
+        }
+        parent.pendingGotos.add(pending);
+      }
+    } else if (isRoot) {
+      if (block.pendingGotos.isNotEmpty) {
+        return _errorNoVisibleLabel(block.pendingGotos.first);
+      }
+    }
+
+    return null;
+  }
+
+  String? _visitStatement(AstNode node, _BlockContext block) {
+    if (node is Label) {
+      return _handleLabel(node, block);
+    }
+
+    if (node is Goto) {
+      block.pendingGotos.add(
+        _PendingGoto(
+          node: node,
+          labelName: node.label.name,
+          activeLocalCount: _activeLocals.length,
+          originBlock: block,
+        ),
+      );
+      return null;
+    }
+
+    if (node is LocalDeclaration) {
+      for (final name in node.names) {
+        _addLocal(name.name, name.span ?? node.span, block);
+      }
+      for (final expr in node.exprs) {
+        final error = _visitExpression(expr, block);
+        if (error != null) return error;
+      }
+      return null;
+    }
+
+    if (node is LocalFunctionDef) {
+      _addLocal(node.name.name, node.name.span ?? node.span, block);
+      return _validateFunctionBody(node.funcBody);
+    }
+
+    if (node is FunctionDef) {
+      return _validateFunctionBody(node.body);
+    }
+
+    if (node is Assignment) {
+      for (final expr in node.exprs) {
+        final error = _visitExpression(expr, block);
+        if (error != null) return error;
+      }
+      return null;
+    }
+
+    if (node is ExpressionStatement) {
+      return _visitExpression(node.expr, block);
+    }
+
+    if (node is ReturnStatement) {
+      for (final expr in node.expr) {
+        final error = _visitExpression(expr, block);
+        if (error != null) return error;
+      }
+      return null;
+    }
+
+    if (node is YieldStatement) {
+      for (final expr in node.expr) {
+        final error = _visitExpression(expr, block);
+        if (error != null) return error;
+      }
+      return null;
+    }
+
+    if (node is DoBlock) {
+      return _withChildBlock(node.body, block);
+    }
+
+    if (node is WhileStatement) {
+      final condError = _visitExpression(node.cond, block);
+      if (condError != null) return condError;
+      return _withChildBlock(node.body, block);
+    }
+
+    if (node is RepeatUntilLoop) {
+      final bodyError = _withChildBlock(node.body, block);
+      if (bodyError != null) return bodyError;
+      return _visitExpression(node.cond, block);
+    }
+
+    if (node is IfStatement) {
+      final condError = _visitExpression(node.cond, block);
+      if (condError != null) return condError;
+
+      final thenError = _withChildBlock(node.thenBlock, block);
+      if (thenError != null) return thenError;
+
+      for (final clause in node.elseIfs) {
+        final clauseCondError = _visitExpression(clause.cond, block);
+        if (clauseCondError != null) return clauseCondError;
+        final clauseError = _withChildBlock(clause.thenBlock, block);
+        if (clauseError != null) return clauseError;
+      }
+
+      if (node.elseBlock.isNotEmpty) {
+        final elseError = _withChildBlock(node.elseBlock, block);
+        if (elseError != null) return elseError;
+      }
+      return null;
+    }
+
+    if (node is ForLoop) {
+      final startError = _visitExpression(node.start, block);
+      if (startError != null) return startError;
+      final endError = _visitExpression(node.endExpr, block);
+      if (endError != null) return endError;
+      final stepError = _visitExpression(node.stepExpr, block);
+      if (stepError != null) return stepError;
+
+      return _withChildBlock(
+        node.body,
+        block,
+        onEnter: (child) =>
+            _addLocal(node.varName.name, node.varName.span, child),
+      );
+    }
+
+    if (node is ForInLoop) {
+      for (final iterator in node.iterators) {
+        final error = _visitExpression(iterator, block);
+        if (error != null) return error;
+      }
+
+      return _withChildBlock(
+        node.body,
+        block,
+        onEnter: (child) {
+          for (final name in node.names) {
+            _addLocal(name.name, name.span ?? node.span, child);
+          }
+        },
+      );
+    }
+
+    if (node is FunctionBody) {
+      return _validateFunctionBody(node);
+    }
+
+    if (node is AssignmentIndexAccessExpr) {
+      final valueError = _visitExpression(node.value, block);
+      if (valueError != null) return valueError;
+      final targetError = _visitExpression(node.target, block);
+      if (targetError != null) return targetError;
+      return _visitExpression(node.index, block);
+    }
+
+    // Other statement types either do not introduce scopes or
+    // do not contain nested statements relevant for goto validation.
+    return null;
+  }
+
+  String? _withChildBlock(
+    List<AstNode> statements,
+    _BlockContext parent, {
+    void Function(_BlockContext child)? onEnter,
+  }) {
+    final child = _BlockContext(
+      parent: parent,
+      depth: parent.depth + 1,
+      activeLocalStartIndex: _activeLocals.length,
+    );
+
+    onEnter?.call(child);
+
+    final error = _processBlock(statements, child);
+    if (error != null) {
+      return error;
+    }
+
+    return _finishBlock(child, isRoot: false);
+  }
+
+  String? _visitExpression(AstNode node, _BlockContext block) {
+    if (node is FunctionLiteral) {
+      return _validateFunctionBody(node.funcBody);
+    }
+
+    if (node is TableConstructor) {
+      for (final entry in node.entries) {
+        final error = _visitExpression(entry, block);
+        if (error != null) return error;
+      }
+      return null;
+    }
+
+    if (node is KeyedTableEntry) {
+      final keyError = _visitExpression(node.key, block);
+      if (keyError != null) return keyError;
+      return _visitExpression(node.value, block);
+    }
+
+    if (node is IndexedTableEntry) {
+      final keyError = _visitExpression(node.key, block);
+      if (keyError != null) return keyError;
+      return _visitExpression(node.value, block);
+    }
+
+    if (node is TableEntryLiteral) {
+      return _visitExpression(node.expr, block);
+    }
+
+    if (node is BinaryExpression) {
+      final leftError = _visitExpression(node.left, block);
+      if (leftError != null) return leftError;
+      return _visitExpression(node.right, block);
+    }
+
+    if (node is UnaryExpression) {
+      return _visitExpression(node.expr, block);
+    }
+
+    if (node is FunctionCall) {
+      final nameError = _visitExpression(node.name, block);
+      if (nameError != null) return nameError;
+      for (final arg in node.args) {
+        final error = _visitExpression(arg, block);
+        if (error != null) return error;
+      }
+      return null;
+    }
+
+    if (node is MethodCall) {
+      final prefixError = _visitExpression(node.prefix, block);
+      if (prefixError != null) return prefixError;
+      final methodError = _visitExpression(node.methodName, block);
+      if (methodError != null) return methodError;
+      for (final arg in node.args) {
+        final error = _visitExpression(arg, block);
+        if (error != null) return error;
+      }
+      return null;
+    }
+
+    if (node is TableAccessExpr) {
+      final targetError = _visitExpression(node.table, block);
+      if (targetError != null) return targetError;
+      return _visitExpression(node.index, block);
+    }
+
+    if (node is GroupedExpression) {
+      return _visitExpression(node.expr, block);
+    }
+
+    if (node is AssignmentIndexAccessExpr) {
+      final targetError = _visitExpression(node.target, block);
+      if (targetError != null) return targetError;
+      final indexError = _visitExpression(node.index, block);
+      if (indexError != null) return indexError;
+      return _visitExpression(node.value, block);
+    }
+
+    // Literals, identifiers, and other nodes do not contain nested
+    // statements that affect goto validation.
+    return null;
+  }
+
+  String? _handleLabel(Label label, _BlockContext block) {
+    final name = label.label.name;
+
+    for (_BlockContext? ctx = block; ctx != null; ctx = ctx.parent) {
+      final current = ctx;
+      if (current.labels.containsKey(name)) {
+        final line = _line(label.span);
+        return "label '$name' already defined at line $line";
+      }
+    }
+
+    block.labels[name] = label;
+
+    for (_BlockContext? ctx = block; ctx != null; ctx = ctx.parent) {
+      final current = ctx;
+      final remaining = <_PendingGoto>[];
+      for (final pending in current.pendingGotos) {
+        if (pending.labelName != name) {
+          remaining.add(pending);
+          continue;
+        }
+
+        if (!pending.originBlock.isDescendantOf(block)) {
+          remaining.add(pending);
+          continue;
+        }
+
+        final error = _validateGotoAgainstLabel(pending);
+        if (error != null) {
+          return error;
+        }
+      }
+      current.pendingGotos
+        ..clear()
+        ..addAll(remaining);
+    }
+
+    return null;
+  }
+
+  String? _validateGotoAgainstLabel(_PendingGoto pending) {
+    if (pending.activeLocalCount < _activeLocals.length) {
+      final local = _activeLocals[pending.activeLocalCount];
+      final line = _line(pending.node.span);
+      return "<goto ${pending.labelName}> at line $line jumps into the scope of local '${local.name}'";
+    }
+    return null;
+  }
+
+  void _addLocal(String name, SourceSpan? span, _BlockContext block) {
+    _activeLocals.add(_LocalInfo(name: name, span: span, declaredIn: block));
+  }
+
+  String _errorNoVisibleLabel(_PendingGoto pending) {
+    final line = _line(pending.node.span);
+    return "no visible label '${pending.labelName}' for <goto> at line $line";
+  }
+
+  String _line(SourceSpan? span) {
+    if (span == null) {
+      return '0';
+    }
+    return (span.start.line + 1).toString();
+  }
+
+  String? _validateFunctionBody(FunctionBody body) {
+    final validator = GotoLabelValidator();
+    return validator.checkFunctionBody(body);
+  }
+}
+
+class _BlockContext {
+  _BlockContext({
+    required this.parent,
+    required this.depth,
+    required this.activeLocalStartIndex,
+  });
+
+  final _BlockContext? parent;
+  final int depth;
+  final int activeLocalStartIndex;
+  final Map<String, Label> labels = {};
+  final List<_PendingGoto> pendingGotos = [];
+
+  bool isDescendantOf(_BlockContext other) {
+    for (_BlockContext? ctx = this; ctx != null; ctx = ctx.parent) {
+      final current = ctx;
+      if (identical(current, other)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+class _PendingGoto {
+  _PendingGoto({
+    required this.node,
+    required this.labelName,
+    required this.activeLocalCount,
+    required this.originBlock,
+  });
+
+  final Goto node;
+  final String labelName;
+  int activeLocalCount;
+  final _BlockContext originBlock;
+}
+
+class _LocalInfo {
+  _LocalInfo({
+    required this.name,
+    required this.span,
+    required this.declaredIn,
+  });
+
+  final String name;
+  final SourceSpan? span;
+  final _BlockContext declaredIn;
+}

--- a/pkgs/lualike/lib/src/io/io_device_io.dart
+++ b/pkgs/lualike/lib/src/io/io_device_io.dart
@@ -9,6 +9,7 @@ import 'io_device.dart';
 import 'lua_file.dart';
 import 'package:lualike/src/utils/platform_utils.dart' as platform;
 import 'package:lualike/src/utils/command_parser.dart';
+import 'package:lualike/src/utils/file_system_utils.dart';
 
 /// Implementation for real files using dart:io
 class FileIODevice extends BaseIODevice {
@@ -819,7 +820,7 @@ class ProcessIODevice extends BaseIODevice {
         parsedCommand.skip(1).toList(),
         mode: ProcessStartMode.normal,
         runInShell: false,
-        workingDirectory: Directory.current.path,
+        workingDirectory: getCurrentDirectory(),
       );
     } else {
       // Use shell for other commands

--- a/pkgs/lualike/lib/src/stdlib/lib_base.dart
+++ b/pkgs/lualike/lib/src/stdlib/lib_base.dart
@@ -6,6 +6,7 @@ import 'package:lualike/src/chunk_serializer.dart';
 import 'package:lualike/lualike.dart';
 
 import 'package:lualike/src/const_checker.dart';
+import 'package:lualike/src/goto_validator.dart';
 import 'package:lualike/src/io/lua_file.dart';
 import 'package:lualike/src/upvalue.dart';
 import 'package:lualike/src/interpreter/upvalue_analyzer.dart';
@@ -962,6 +963,12 @@ class LoadFunction extends BuiltinFunction {
         }
         // Return error in load() format: [nil, error_message]
         return [Value(null), Value(adjustedError)];
+      }
+
+      final gotoValidator = GotoLabelValidator();
+      final gotoError = gotoValidator.checkGotoLabelViolations(ast);
+      if (gotoError != null) {
+        return [Value(null), Value(gotoError)];
       }
 
       final sourceFile = path.url.joinAll(

--- a/pkgs/lualike/lib/src/stdlib/lib_debug.dart
+++ b/pkgs/lualike/lib/src/stdlib/lib_debug.dart
@@ -4,6 +4,7 @@ import 'package:lualike/src/coroutine.dart';
 import 'package:lualike/src/io/lua_file.dart';
 import 'package:lualike/src/stdlib/lib_io.dart';
 import 'package:lualike/src/stdlib/metatables.dart';
+import 'package:lualike/src/upvalue.dart';
 import 'library.dart';
 
 class DebugLib {
@@ -383,8 +384,25 @@ class _UpvalueId extends BuiltinFunction {
     if (args.length < 2) {
       throw Exception("debug.upvalueid requires function and index");
     }
-    // Return unique id for upvalue
-    return Value(null);
+    final functionArg = args[0] as Value;
+    final indexArg = args[1] as Value;
+
+    if (indexArg.raw is! num) {
+      throw Exception("debug.upvalueid index must be a number");
+    }
+
+    final index = (indexArg.raw as num).toInt();
+    if (index < 1) {
+      return Value(null);
+    }
+
+    final upvalues = functionArg.upvalues;
+    if (upvalues == null || index > upvalues.length) {
+      return Value(null);
+    }
+
+    final Upvalue upvalue = upvalues[index - 1];
+    return Value(upvalue.canonicalBox);
   }
 }
 

--- a/pkgs/lualike/lib/src/stdlib/lib_os.dart
+++ b/pkgs/lualike/lib/src/stdlib/lib_os.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:lualike/lualike.dart';
 
 import 'package:lualike/src/utils/file_system_utils.dart';
@@ -296,7 +294,7 @@ class _OSExecute extends BuiltinFunction {
         result = runProcessSync(
           parsedCommand[0],
           parsedCommand.skip(1).toList(),
-          workingDirectory: Directory.current.path,
+          workingDirectory: getCurrentDirectory(),
         );
       } else {
         // Use shell for other commands

--- a/pkgs/lualike/lib/src/upvalue.dart
+++ b/pkgs/lualike/lib/src/upvalue.dart
@@ -105,6 +105,20 @@ class Upvalue extends GCObject {
   /// Whether this upvalue has been joined with another upvalue
   bool get isJoined => _joinedUpvalue != null;
 
+  /// Returns the canonical storage box backing this upvalue, taking into
+  /// account any joins performed via debug.upvaluejoin. When joined, all
+  /// participating upvalues resolve to the same underlying box to mirror
+  /// Lua's pointer identity semantics for upvalues.
+  Box<dynamic> get canonicalBox {
+    var current = this;
+    final visited = <Upvalue>{};
+    while (current._joinedUpvalue != null && !visited.contains(current)) {
+      visited.add(current);
+      current = current._joinedUpvalue!;
+    }
+    return current.valueBox;
+  }
+
   @override
   List<Object?> getReferences() {
     final refs = <Object?>[];

--- a/pkgs/lualike/luascripts/test/goto.lua
+++ b/pkgs/lualike/luascripts/test/goto.lua
@@ -1,0 +1,271 @@
+-- $Id: testes/goto.lua $
+-- See Copyright Notice in file all.lua
+
+collectgarbage()
+
+local function errmsg (code, m)
+  local st, msg = load(code)
+  assert(not st and string.find(msg, m))
+end
+
+-- cannot see label inside block
+errmsg([[ goto l1; do ::l1:: end ]], "label 'l1'")
+errmsg([[ do ::l1:: end goto l1; ]], "label 'l1'")
+
+-- repeated label
+errmsg([[ ::l1:: ::l1:: ]], "label 'l1'")
+errmsg([[ ::l1:: do ::l1:: end]], "label 'l1'")
+
+
+-- undefined label
+errmsg([[ goto l1; local aa ::l1:: ::l2:: print(3) ]], "local 'aa'")
+
+-- jumping over variable definition
+errmsg([[
+do local bb, cc; goto l1; end
+local aa
+::l1:: print(3)
+]], "local 'aa'")
+
+-- jumping into a block
+errmsg([[ do ::l1:: end goto l1 ]], "label 'l1'")
+errmsg([[ goto l1 do ::l1:: end ]], "label 'l1'")
+
+-- cannot continue a repeat-until with variables
+errmsg([[
+  repeat
+    if x then goto cont end
+    local xuxu = 10
+    ::cont::
+  until xuxu < x
+]], "local 'xuxu'")
+
+-- simple gotos
+local x
+do
+  local y = 12
+  goto l1
+  ::l2:: x = x + 1; goto l3
+  ::l1:: x = y; goto l2
+end
+::l3:: ::l3_1:: assert(x == 13)
+
+
+-- long labels
+do
+  local prog = [[
+  do
+    local a = 1
+    goto l%sa; a = a + 1
+   ::l%sa:: a = a + 10
+    goto l%sb; a = a + 2
+   ::l%sb:: a = a + 20
+    return a
+  end
+  ]]
+  local label = string.rep("0123456789", 40)
+  prog = string.format(prog, label, label, label, label)
+  assert(assert(load(prog))() == 31)
+end
+
+
+-- ok to jump over local dec. to end of block
+do
+  goto l1
+  local a = 23
+  x = a
+  ::l1::;
+end
+
+while true do
+  goto l4
+  goto l1  -- ok to jump over local dec. to end of block
+  goto l1  -- multiple uses of same label
+  local x = 45
+  ::l1:: ;;;
+end
+::l4:: assert(x == 13)
+
+if print then
+  goto l1   -- ok to jump over local dec. to end of block
+  error("should not be here")
+  goto l2   -- ok to jump over local dec. to end of block
+  local x
+  ::l1:: ; ::l2:: ;;
+else end
+
+-- to repeat a label in a different function is OK
+local function foo ()
+  local a = {}
+  goto l3
+  ::l1:: a[#a + 1] = 1; goto l2;
+  ::l2:: a[#a + 1] = 2; goto l5;
+  ::l3::
+  ::l3a:: a[#a + 1] = 3; goto l1;
+  ::l4:: a[#a + 1] = 4; goto l6;
+  ::l5:: a[#a + 1] = 5; goto l4;
+  ::l6:: assert(a[1] == 3 and a[2] == 1 and a[3] == 2 and
+              a[4] == 5 and a[5] == 4)
+  if not a[6] then a[6] = true; goto l3a end   -- do it twice
+end
+
+::l6:: foo()
+
+
+do   -- bug in 5.2 -> 5.3.2
+  local x
+  ::L1::
+  local y             -- cannot join this SETNIL with previous one
+  assert(y == nil)
+  y = true
+  if x == nil then
+    x = 1
+    goto L1
+  else
+    x = x + 1
+  end
+  assert(x == 2 and y == true)
+end
+
+-- bug in 5.3
+do
+  local first = true
+  local a = false
+  if true then
+    goto LBL
+    ::loop::
+    a = true
+    ::LBL::
+    if first then
+      first = false
+      goto loop
+    end
+  end
+  assert(a)
+end
+
+do   -- compiling infinite loops
+  goto escape   -- do not run the infinite loops
+  ::a:: goto a
+  ::b:: goto c
+  ::c:: goto b
+end
+::escape::
+--------------------------------------------------------------------------------
+-- testing closing of upvalues
+
+local debug = require 'debug'
+
+local function foo ()
+  local t = {}
+  do
+  local i = 1
+  local a, b, c, d
+  t[1] = function () return a, b, c, d end
+  ::l1::
+  local b
+  do
+    local c
+    t[#t + 1] = function () return a, b, c, d end    -- t[2], t[4], t[6]
+    if i > 2 then goto l2 end
+    do
+      local d
+      t[#t + 1] = function () return a, b, c, d end   -- t[3], t[5]
+      i = i + 1
+      local a
+      goto l1
+    end
+  end
+  end
+  ::l2:: return t
+end
+
+local a = foo()
+assert(#a == 6)
+
+-- all functions share same 'a'
+for i = 2, 6 do
+  assert(debug.upvalueid(a[1], 1) == debug.upvalueid(a[i], 1))
+end
+
+-- 'b' and 'c' are shared among some of them
+for i = 2, 6 do
+  -- only a[1] uses external 'b'/'b'
+  assert(debug.upvalueid(a[1], 2) ~= debug.upvalueid(a[i], 2))
+  assert(debug.upvalueid(a[1], 3) ~= debug.upvalueid(a[i], 3))
+end
+
+for i = 3, 5, 2 do
+  -- inner functions share 'b'/'c' with previous ones
+  assert(debug.upvalueid(a[i], 2) == debug.upvalueid(a[i - 1], 2))
+  assert(debug.upvalueid(a[i], 3) == debug.upvalueid(a[i - 1], 3))
+  -- but not with next ones
+  assert(debug.upvalueid(a[i], 2) ~= debug.upvalueid(a[i + 1], 2))
+  assert(debug.upvalueid(a[i], 3) ~= debug.upvalueid(a[i + 1], 3))
+end
+
+-- only external 'd' is shared
+for i = 2, 6, 2 do
+  assert(debug.upvalueid(a[1], 4) == debug.upvalueid(a[i], 4))
+end
+
+-- internal 'd's are all different
+for i = 3, 5, 2 do
+  for j = 1, 6 do
+    assert((debug.upvalueid(a[i], 4) == debug.upvalueid(a[j], 4))
+      == (i == j))
+  end
+end
+
+--------------------------------------------------------------------------------
+-- testing if x goto optimizations
+
+local function testG (a)
+  if a == 1 then
+    goto l1
+    error("should never be here!")
+  elseif a == 2 then goto l2
+  elseif a == 3 then goto l3
+  elseif a == 4 then
+    goto l1  -- go to inside the block
+    error("should never be here!")
+    ::l1:: a = a + 1   -- must go to 'if' end
+  else
+    goto l4
+    ::l4a:: a = a * 2; goto l4b
+    error("should never be here!")
+    ::l4:: goto l4a
+    error("should never be here!")
+    ::l4b::
+  end
+  do return a end
+  ::l2:: do return "2" end
+  ::l3:: do return "3" end
+  ::l1:: return "1"
+end
+
+assert(testG(1) == "1")
+assert(testG(2) == "2")
+assert(testG(3) == "3")
+assert(testG(4) == 5)
+assert(testG(5) == 10)
+
+do
+  -- if x back goto out of scope of upvalue
+  local X
+  goto L1
+
+  ::L2:: goto L3
+
+  ::L1:: do
+    local a <close> = setmetatable({}, {__close = function () X = true end})
+    assert(X == nil)
+    if a then goto L2 end   -- jumping back out of scope of 'a'
+  end
+
+  ::L3:: assert(X == true)   -- checks that 'a' was correctly closed
+end
+--------------------------------------------------------------------------------
+
+
+print'OK'

--- a/pkgs/lualike/test/stdlib/load_goto_validator_test.dart
+++ b/pkgs/lualike/test/stdlib/load_goto_validator_test.dart
@@ -1,0 +1,36 @@
+import 'package:lualike_test/test.dart';
+
+void main() {
+  group('load() goto validation', () {
+    late LuaLike lua;
+
+    setUp(() => lua = LuaLike());
+
+    test('rejects goto jumping into local scope', () async {
+      await lua.execute(r'''
+        f, err = load("goto l1; local aa ::l1:: print(3)")
+      ''');
+
+      final f = lua.getGlobal('f') as Value;
+      final err = lua.getGlobal('err') as Value;
+
+      expect(f.unwrap(), isNull);
+      expect(err.unwrap(), contains("local 'aa'"));
+    });
+
+    test('allows valid forward goto', () async {
+      await lua.execute(r'''
+        loader, loadErr = load([[goto finish; do local x = 1 end ::finish:: return 42]])
+      ''');
+
+      final loader = lua.getGlobal('loader') as Value;
+      final loadErr = lua.getGlobal('loadErr') as Value;
+
+      expect(loader.unwrap(), isNotNull);
+      expect(loadErr.unwrap(), isNull);
+
+      final result = await lua.execute('return loader()') as Value;
+      expect(result.unwrap(), equals(42));
+    });
+  });
+}

--- a/pkgs/lualike/tool/test.dart
+++ b/pkgs/lualike/tool/test.dart
@@ -13,6 +13,7 @@ import 'utils.dart';
 final testFiles = [
   'calls.lua',
   'attrib.lua',
+  'goto.lua',
   'bitwise.lua',
   'constructs.lua',
   'strings.lua',

--- a/pkgs/lualike/web/examples.dart
+++ b/pkgs/lualike/web/examples.dart
@@ -339,7 +339,7 @@ stringFile:close()''',
   };
 
   // Get all example keys
-    static List<String> get keys => examples.keys.toList()..sort();
+  static List<String> get keys => examples.keys.toList()..sort();
 
   // Get example code by key
   static String? getExample(String key) => examples[key];

--- a/pkgs/lualike/web/examples.dart
+++ b/pkgs/lualike/web/examples.dart
@@ -76,6 +76,30 @@ print("Counter: " .. counter()) -- 11
 print("Counter: " .. counter()) -- 12
 print("Counter: " .. counter()) -- 13''',
 
+    'goto': '''-- Goto and Labels
+print("Starting goto demo")
+
+local total = 0
+local i = 1
+
+::loop::
+if i > 5 then
+    goto finish
+end
+
+total = total + i
+i = i + 1
+goto loop
+
+::finish::
+print("Sum of the first five integers is " .. total)
+
+local message = "before"
+goto skip
+message = "this line is skipped"
+::skip::
+print("Final message: " .. message)''',
+
     'metatable': '''-- Metatables Example
 -- Create a vector class
 Vector = {}
@@ -301,6 +325,7 @@ stringFile:close()''',
   // Display names for the examples
   static const Map<String, String> displayNames = {
     'hello': 'Hello World',
+    'goto': 'Goto and Labels',
     'fibonacci': 'Fibonacci Sequence',
     'table': 'Table Operations',
     'functions': 'Functions & Closures',
@@ -314,7 +339,7 @@ stringFile:close()''',
   };
 
   // Get all example keys
-  static List<String> get keys => examples.keys.toList();
+    static List<String> get keys => examples.keys.toList()..sort();
 
   // Get example code by key
   static String? getExample(String key) => examples[key];


### PR DESCRIPTION
This pull request introduces comprehensive support for Lua's `goto` statement and label validation, ensuring correct semantics and error handling in accordance with the Lua language specification. The changes include implementation of a validator for `goto` label violations, updates to the standard library to invoke this validator during code loading, enhancements to upvalue identity semantics for debugging, new tests for `goto` validation, and expanded documentation and examples for users.

**Goto statement and label validation:**

* Added `GotoLabelValidator` to check for invalid `goto` label usage during code loading, such as jumping into local scope or repeated/undefined labels. The validator is now invoked in the `LoadFunction` implementation, returning appropriate error messages when violations are detected. [[1]](diffhunk://#diff-43dbe4a75253f486542cdae1637fb71b6d522afbec1255aa899df63a455d0e58R9) [[2]](diffhunk://#diff-43dbe4a75253f486542cdae1637fb71b6d522afbec1255aa899df63a455d0e58R968-R973)

**Upvalue identity and debugging enhancements:**

* Implemented the `canonicalBox` getter in the `Upvalue` class to ensure correct pointer identity for joined upvalues, mirroring Lua's semantics. Updated the `debug.upvalueid` function to use this canonical identity for upvalues. [[1]](diffhunk://#diff-2cb5500bd5953a1ad57440d29e23108f8eddd041025ce49f659a039b5ba34dafR108-R121) [[2]](diffhunk://#diff-daa653d3a869ecbb54d0f29d2365f75dc20aefcfecf08a391446a11fbae9c969L386-R406)

**Platform and file system improvements:**

* Replaced direct usage of `Directory.current.path` with the new `getCurrentDirectory()` helper for improved portability in process execution, affecting both IO and OS standard library implementations. [[1]](diffhunk://#diff-466d6ad9ea084642a03c468fc3d4c93923c14b0dc38145e10611de09be801e7fL822-R823) [[2]](diffhunk://#diff-51cd8f6d7a08aad55fd0c4dbd06018cbad62d509a3dcfd82ea5982289d64f391L299-R297) [[3]](diffhunk://#diff-466d6ad9ea084642a03c468fc3d4c93923c14b0dc38145e10611de09be801e7fR12) [[4]](diffhunk://#diff-51cd8f6d7a08aad55fd0c4dbd06018cbad62d509a3dcfd82ea5982289d64f391L1-L2)

**Testing and validation:**

* Added new Dart tests for `goto` validation in `load()`, verifying correct rejection of invalid jumps and acceptance of valid ones.

**Documentation and examples:**

* Added a comprehensive Lua test script for `goto` and label usage, and updated web examples and tooling to include `goto` demonstrations and documentation. [[1]](diffhunk://#diff-4ed82189285e75ca7b7d65f5787a9f18bbc32ff5a257c7627fd281e3a0fad8c8R1-R271) [[2]](diffhunk://#diff-d936dcd29b608a4d0070b2cb7e508770668afcbc147617595982a002e864c826R16) [[3]](diffhunk://#diff-ec0b127ae268093305bc47d5fe25709bfc3e13609fdd82a85728f1d6218a7a5eR79-R102) [[4]](diffhunk://#diff-ec0b127ae268093305bc47d5fe25709bfc3e13609fdd82a85728f1d6218a7a5eR328) [[5]](diffhunk://#diff-ec0b127ae268093305bc47d5fe25709bfc3e13609fdd82a85728f1d6218a7a5eL317-R342)