### PR TITLE
Improve Lua parser profiling performance

### DIFF
--- a/pkgs/lualike/.gitignore
+++ b/pkgs/lualike/.gitignore
@@ -31,3 +31,9 @@ bin/lualike_dbg2
 benchmarks/*
 !benchmarks/tt_after_env_cache.log
 !benchmarks/tt_before_env_cache.log
+!benchmarks/parser_profiles/
+benchmarks/parser_profiles/*
+!benchmarks/parser_profiles/*-baseline-*.json
+!benchmarks/parser_profiles/*-latest-*.json
+!benchmarks/parser_profiles/*-comparison-*.json
+!benchmarks/parser_profiles/*-comparison-*.md

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-baseline-hot.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-baseline-hot.json
@@ -1,0 +1,297 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T09:20:32.108089",
+  "label": "origin/ir hot-lua-suite",
+  "packageRoot": "/tmp/lualike-parser-baseline.CDSBTL/pkgs/lualike",
+  "git": {
+    "revision": "ae3c7fc3eef66bd317eb7c637d3add0d53bf96eb",
+    "branch": null,
+    "dirty": true,
+    "statusShort": [
+      "M ../../pubspec.lock",
+      "?? luascripts/parser_profiles/",
+      "?? tool/parser_profile.dart",
+      "?? tool/parser_profile_compare.dart"
+    ]
+  },
+  "corpus": {
+    "directory": "/tmp/lualike-parser-baseline.CDSBTL/pkgs/lualike/luascripts",
+    "relativeDirectory": "luascripts"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=origin/ir hot-lua-suite",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-baseline-hot.json",
+    "--no-fail-fast",
+    "-c",
+    "strings",
+    "-c",
+    "test/api",
+    "-c",
+    "test/files",
+    "-c",
+    "test/math",
+    "-c",
+    "test/db",
+    "-c",
+    "test/locals",
+    "-c",
+    "test/code",
+    "-c",
+    "test/pm",
+    "-c",
+    "test/strings",
+    "--corpus=luascripts"
+  ],
+  "rows": [
+    {
+      "case": "strings",
+      "path": "luascripts/strings.lua",
+      "source": {
+        "characters": 18253,
+        "lines": 518,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        472491,
+        455311,
+        781945,
+        522471,
+        540208,
+        538900,
+        699404,
+        643111,
+        527978,
+        493899
+      ],
+      "minMicros": 455311,
+      "meanMicros": 567571.8,
+      "medianMicros": 533439.0,
+      "maxMicros": 781945,
+      "charsPerSecond": 32159.8077987666
+    },
+    {
+      "case": "test/api",
+      "path": "luascripts/test/api.lua",
+      "source": {
+        "characters": 40029,
+        "lines": 1417,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        252538,
+        327129,
+        273073,
+        337031,
+        298434,
+        343082,
+        299311,
+        265928,
+        325567,
+        403232
+      ],
+      "minMicros": 252538,
+      "meanMicros": 312532.5,
+      "medianMicros": 312439.0,
+      "maxMicros": 403232,
+      "charsPerSecond": 128079.47973410766
+    },
+    {
+      "case": "test/code",
+      "path": "luascripts/test/code.lua",
+      "source": {
+        "characters": 14715,
+        "lines": 505,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        247691,
+        292164,
+        284414,
+        215534,
+        243143,
+        240335,
+        272341,
+        249927,
+        216992,
+        283933
+      ],
+      "minMicros": 215534,
+      "meanMicros": 254647.4,
+      "medianMicros": 248809.0,
+      "maxMicros": 292164,
+      "charsPerSecond": 57785.78536439014
+    },
+    {
+      "case": "test/db",
+      "path": "luascripts/test/db.lua",
+      "source": {
+        "characters": 26597,
+        "lines": 1066,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        286278,
+        253330,
+        242721,
+        231239,
+        207267,
+        246640,
+        312136,
+        322323,
+        265959,
+        287365
+      ],
+      "minMicros": 207267,
+      "meanMicros": 265525.8,
+      "medianMicros": 259644.5,
+      "maxMicros": 322323,
+      "charsPerSecond": 100167.29071148642
+    },
+    {
+      "case": "test/files",
+      "path": "luascripts/test/files.lua",
+      "source": {
+        "characters": 28151,
+        "lines": 1011,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        289941,
+        291434,
+        273771,
+        284481,
+        277625,
+        261184,
+        289617,
+        265141,
+        282350,
+        292549
+      ],
+      "minMicros": 261184,
+      "meanMicros": 280809.3,
+      "medianMicros": 283415.5,
+      "maxMicros": 292549,
+      "charsPerSecond": 100249.5287727294
+    },
+    {
+      "case": "test/locals",
+      "path": "luascripts/test/locals.lua",
+      "source": {
+        "characters": 30652,
+        "lines": 1228,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        141196,
+        138807,
+        176328,
+        169516,
+        148688,
+        147452,
+        155663,
+        154977,
+        158099,
+        174076
+      ],
+      "minMicros": 138807,
+      "meanMicros": 156480.2,
+      "medianMicros": 155320.0,
+      "maxMicros": 176328,
+      "charsPerSecond": 195884.20771445843
+    },
+    {
+      "case": "test/math",
+      "path": "luascripts/test/math.lua",
+      "source": {
+        "characters": 33144,
+        "lines": 1146,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        230634,
+        242380,
+        238360,
+        303612,
+        271441,
+        244100,
+        268786,
+        282551,
+        277181,
+        279774
+      ],
+      "minMicros": 230634,
+      "meanMicros": 263881.9,
+      "medianMicros": 270113.5,
+      "maxMicros": 303612,
+      "charsPerSecond": 125601.64224980948
+    },
+    {
+      "case": "test/pm",
+      "path": "luascripts/test/pm.lua",
+      "source": {
+        "characters": 13818,
+        "lines": 443,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        496032,
+        430126,
+        411370,
+        427502,
+        435096,
+        447532,
+        422387,
+        543273,
+        473115,
+        581324
+      ],
+      "minMicros": 411370,
+      "meanMicros": 466775.7,
+      "medianMicros": 441314.0,
+      "maxMicros": 581324,
+      "charsPerSecond": 29603.08345100227
+    },
+    {
+      "case": "test/strings",
+      "path": "luascripts/test/strings.lua",
+      "source": {
+        "characters": 19405,
+        "lines": 564,
+        "encoding": "latin1"
+      },
+      "samplesMicros": [
+        465369,
+        499746,
+        443735,
+        587709,
+        482613,
+        512896,
+        485377,
+        705490,
+        735033,
+        603146
+      ],
+      "minMicros": 443735,
+      "meanMicros": 552111.4,
+      "medianMicros": 506321.0,
+      "maxMicros": 735033,
+      "charsPerSecond": 35146.89245684838
+    }
+  ],
+  "total": {
+    "meanMicros": 3120336.0,
+    "meanMs": 3120.336
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-baseline-small.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-baseline-small.json
@@ -1,0 +1,200 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T09:19:35.586857",
+  "label": "origin/ir small-parser-corpus",
+  "packageRoot": "/tmp/lualike-parser-baseline.CDSBTL/pkgs/lualike",
+  "git": {
+    "revision": "ae3c7fc3eef66bd317eb7c637d3add0d53bf96eb",
+    "branch": null,
+    "dirty": true,
+    "statusShort": [
+      "M ../../pubspec.lock",
+      "?? luascripts/parser_profiles/",
+      "?? tool/parser_profile.dart",
+      "?? tool/parser_profile_compare.dart"
+    ]
+  },
+  "corpus": {
+    "directory": "/tmp/lualike-parser-baseline.CDSBTL/pkgs/lualike/luascripts/parser_profiles",
+    "relativeDirectory": "luascripts/parser_profiles"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=origin/ir small-parser-corpus",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-baseline-small.json",
+    "--no-fail-fast"
+  ],
+  "rows": [
+    {
+      "case": "attributes_and_labels",
+      "path": "luascripts/parser_profiles/attributes_and_labels.lua",
+      "source": {
+        "characters": 122,
+        "lines": 11,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        3241,
+        3210,
+        3659,
+        2849,
+        3101,
+        3930,
+        2661,
+        2778,
+        3285,
+        2671
+      ],
+      "minMicros": 2661,
+      "meanMicros": 3138.5,
+      "medianMicros": 3155.5,
+      "maxMicros": 3930,
+      "charsPerSecond": 38872.072646168555
+    },
+    {
+      "case": "branches_and_loops",
+      "path": "luascripts/parser_profiles/branches_and_loops.lua",
+      "source": {
+        "characters": 263,
+        "lines": 22,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        1271,
+        1470,
+        1232,
+        1496,
+        1160,
+        1117,
+        1147,
+        1482,
+        1160,
+        1971
+      ],
+      "minMicros": 1117,
+      "meanMicros": 1350.6,
+      "medianMicros": 1251.5,
+      "maxMicros": 1971,
+      "charsPerSecond": 194728.26891751814
+    },
+    {
+      "case": "functions_and_calls",
+      "path": "luascripts/parser_profiles/functions_and_calls.lua",
+      "source": {
+        "characters": 261,
+        "lines": 15,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        1008,
+        1554,
+        1241,
+        1369,
+        1410,
+        1310,
+        1419,
+        1426,
+        1464,
+        1223
+      ],
+      "minMicros": 1008,
+      "meanMicros": 1342.4,
+      "medianMicros": 1389.5,
+      "maxMicros": 1554,
+      "charsPerSecond": 194427.89034564956
+    },
+    {
+      "case": "literals_and_expressions",
+      "path": "luascripts/parser_profiles/literals_and_expressions.lua",
+      "source": {
+        "characters": 152,
+        "lines": 6,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        1030,
+        1142,
+        1332,
+        963,
+        1001,
+        991,
+        1065,
+        959,
+        949,
+        931
+      ],
+      "minMicros": 931,
+      "meanMicros": 1036.3,
+      "medianMicros": 996.0,
+      "maxMicros": 1332,
+      "charsPerSecond": 146675.6730676445
+    },
+    {
+      "case": "strings_and_comments",
+      "path": "luascripts/parser_profiles/strings_and_comments.lua",
+      "source": {
+        "characters": 254,
+        "lines": 13,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        3654,
+        3335,
+        2357,
+        3043,
+        3031,
+        2276,
+        2012,
+        2489,
+        2695,
+        2278
+      ],
+      "minMicros": 2012,
+      "meanMicros": 2717.0,
+      "medianMicros": 2592.0,
+      "maxMicros": 3654,
+      "charsPerSecond": 93485.46190651454
+    },
+    {
+      "case": "table_shapes",
+      "path": "luascripts/parser_profiles/table_shapes.lua",
+      "source": {
+        "characters": 233,
+        "lines": 12,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        3676,
+        4130,
+        2785,
+        2808,
+        2240,
+        3287,
+        2203,
+        3134,
+        2084,
+        2509
+      ],
+      "minMicros": 2084,
+      "meanMicros": 2885.6,
+      "medianMicros": 2796.5,
+      "maxMicros": 4130,
+      "charsPerSecond": 80745.77210978653
+    }
+  ],
+  "total": {
+    "meanMicros": 12470.4,
+    "meanMs": 12.4704
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-comparison-hot.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-comparison-hot.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile_compare.dart",
+  "title": "Hot Lua Suite",
+  "generatedAt": "2026-05-03T09:22:11.365594",
+  "baseline": {
+    "label": "origin/ir hot-lua-suite",
+    "capturedAt": "2026-05-03T09:20:32.108089",
+    "revision": "ae3c7fc3eef66bd317eb7c637d3add0d53bf96eb",
+    "branch": null
+  },
+  "latest": {
+    "label": "current hot-lua-suite",
+    "capturedAt": "2026-05-03T09:20:40.208016",
+    "revision": "a85d083aee335b3963edc70da5de78296c0a7caa",
+    "branch": "profiling/parser-performance"
+  },
+  "rows": [
+    {
+      "case": "strings",
+      "baselineMeanMicros": 567571.8,
+      "latestMeanMicros": 12790.3,
+      "timeReductionPercent": 97.74648775714367,
+      "speedup": 44.37517493725715
+    },
+    {
+      "case": "test/api",
+      "baselineMeanMicros": 312532.5,
+      "latestMeanMicros": 18428.6,
+      "timeReductionPercent": 94.10346124003105,
+      "speedup": 16.959101613795948
+    },
+    {
+      "case": "test/code",
+      "baselineMeanMicros": 254647.4,
+      "latestMeanMicros": 7078.1,
+      "timeReductionPercent": 97.22043107449753,
+      "speedup": 35.97680168406776
+    },
+    {
+      "case": "test/db",
+      "baselineMeanMicros": 265525.8,
+      "latestMeanMicros": 9209.3,
+      "timeReductionPercent": 96.5316741348675,
+      "speedup": 28.83235425059451
+    },
+    {
+      "case": "test/files",
+      "baselineMeanMicros": 280809.3,
+      "latestMeanMicros": 9041.3,
+      "timeReductionPercent": 96.78027045400562,
+      "speedup": 31.05850928516917
+    },
+    {
+      "case": "test/locals",
+      "baselineMeanMicros": 156480.2,
+      "latestMeanMicros": 8359.6,
+      "timeReductionPercent": 94.65772666445977,
+      "speedup": 18.718622900617255
+    },
+    {
+      "case": "test/math",
+      "baselineMeanMicros": 263881.9,
+      "latestMeanMicros": 11484.7,
+      "timeReductionPercent": 95.64778789299304,
+      "speedup": 22.976821336212527
+    },
+    {
+      "case": "test/pm",
+      "baselineMeanMicros": 466775.7,
+      "latestMeanMicros": 4443.7,
+      "timeReductionPercent": 99.04800099919511,
+      "speedup": 105.04212705628193
+    },
+    {
+      "case": "test/strings",
+      "baselineMeanMicros": 552111.4,
+      "latestMeanMicros": 6560.4,
+      "timeReductionPercent": 98.81176153942845,
+      "speedup": 84.15819157368453
+    }
+  ],
+  "total": {
+    "baselineMeanMicros": 3120336.0,
+    "latestMeanMicros": 87396.0,
+    "timeReductionPercent": 97.19914778408479,
+    "speedup": 35.7034189207744
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-comparison-hot.md
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-comparison-hot.md
@@ -1,0 +1,26 @@
+# Hot Lua Suite
+
+Generated: `2026-05-03T09:22:11.365594`
+
+Baseline: `origin/ir hot-lua-suite`, revision `ae3c7fc3eef6`, captured `2026-05-03T09:20:32.108089`
+
+Latest: `current hot-lua-suite`, revision `a85d083aee33`, branch `profiling/parser-performance`, captured `2026-05-03T09:20:40.208016`
+
+Percentage improvement is mean parse-time reduction:
+
+```text
+(baseline mean - latest mean) / baseline mean
+```
+
+| Case | Baseline | Latest | Reduction | Speedup |
+| --- | ---: | ---: | ---: | ---: |
+| `strings` | `567.572 ms` | `12.790 ms` | `97.7%` | `44.4x` |
+| `test/api` | `312.533 ms` | `18.429 ms` | `94.1%` | `17.0x` |
+| `test/code` | `254.647 ms` | `7.078 ms` | `97.2%` | `36.0x` |
+| `test/db` | `265.526 ms` | `9.209 ms` | `96.5%` | `28.8x` |
+| `test/files` | `280.809 ms` | `9.041 ms` | `96.8%` | `31.1x` |
+| `test/locals` | `156.480 ms` | `8.360 ms` | `94.7%` | `18.7x` |
+| `test/math` | `263.882 ms` | `11.485 ms` | `95.6%` | `23.0x` |
+| `test/pm` | `466.776 ms` | `4.444 ms` | `99.0%` | `105.0x` |
+| `test/strings` | `552.111 ms` | `6.560 ms` | `98.8%` | `84.2x` |
+| **Total** | `3120.336 ms` | `87.396 ms` | **`97.2%`** | **`35.7x`** |

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-comparison-small.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-comparison-small.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile_compare.dart",
+  "title": "Small Parser Corpus",
+  "generatedAt": "2026-05-03T09:22:10.511352",
+  "baseline": {
+    "label": "origin/ir small-parser-corpus",
+    "capturedAt": "2026-05-03T09:19:35.586857",
+    "revision": "ae3c7fc3eef66bd317eb7c637d3add0d53bf96eb",
+    "branch": null
+  },
+  "latest": {
+    "label": "current small-parser-corpus",
+    "capturedAt": "2026-05-03T09:19:40.305093",
+    "revision": "a85d083aee335b3963edc70da5de78296c0a7caa",
+    "branch": "profiling/parser-performance"
+  },
+  "rows": [
+    {
+      "case": "attributes_and_labels",
+      "baselineMeanMicros": 3138.5,
+      "latestMeanMicros": 1001.8,
+      "timeReductionPercent": 68.08029313366256,
+      "speedup": 3.1328608504691555
+    },
+    {
+      "case": "branches_and_loops",
+      "baselineMeanMicros": 1350.6,
+      "latestMeanMicros": 1032.8,
+      "timeReductionPercent": 23.530282837257513,
+      "speedup": 1.307707203718048
+    },
+    {
+      "case": "functions_and_calls",
+      "baselineMeanMicros": 1342.4,
+      "latestMeanMicros": 655.4,
+      "timeReductionPercent": 51.176996424314666,
+      "speedup": 2.0482148306377788
+    },
+    {
+      "case": "literals_and_expressions",
+      "baselineMeanMicros": 1036.3,
+      "latestMeanMicros": 476.2,
+      "timeReductionPercent": 54.04805558236031,
+      "speedup": 2.1761864762704746
+    },
+    {
+      "case": "strings_and_comments",
+      "baselineMeanMicros": 2717.0,
+      "latestMeanMicros": 239.2,
+      "timeReductionPercent": 91.19617224880383,
+      "speedup": 11.358695652173914
+    },
+    {
+      "case": "table_shapes",
+      "baselineMeanMicros": 2885.6,
+      "latestMeanMicros": 647.1,
+      "timeReductionPercent": 77.57485444968118,
+      "speedup": 4.4592798640086535
+    }
+  ],
+  "total": {
+    "baselineMeanMicros": 12470.4,
+    "latestMeanMicros": 4052.4999999999995,
+    "timeReductionPercent": 67.50304721580703,
+    "speedup": 3.077211597779149
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-comparison-small.md
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-comparison-small.md
@@ -1,0 +1,23 @@
+# Small Parser Corpus
+
+Generated: `2026-05-03T09:22:10.511352`
+
+Baseline: `origin/ir small-parser-corpus`, revision `ae3c7fc3eef6`, captured `2026-05-03T09:19:35.586857`
+
+Latest: `current small-parser-corpus`, revision `a85d083aee33`, branch `profiling/parser-performance`, captured `2026-05-03T09:19:40.305093`
+
+Percentage improvement is mean parse-time reduction:
+
+```text
+(baseline mean - latest mean) / baseline mean
+```
+
+| Case | Baseline | Latest | Reduction | Speedup |
+| --- | ---: | ---: | ---: | ---: |
+| `attributes_and_labels` | `3.139 ms` | `1.002 ms` | `68.1%` | `3.1x` |
+| `branches_and_loops` | `1.351 ms` | `1.033 ms` | `23.5%` | `1.3x` |
+| `functions_and_calls` | `1.342 ms` | `0.655 ms` | `51.2%` | `2.0x` |
+| `literals_and_expressions` | `1.036 ms` | `0.476 ms` | `54.0%` | `2.2x` |
+| `strings_and_comments` | `2.717 ms` | `0.239 ms` | `91.2%` | `11.4x` |
+| `table_shapes` | `2.886 ms` | `0.647 ms` | `77.6%` | `4.5x` |
+| **Total** | `12.470 ms` | `4.052 ms` | **`67.5%`** | **`3.1x`** |

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-latest-hot.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-latest-hot.json
@@ -1,0 +1,292 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T09:20:40.208016",
+  "label": "current hot-lua-suite",
+  "packageRoot": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike",
+  "git": {
+    "revision": "a85d083aee335b3963edc70da5de78296c0a7caa",
+    "branch": "profiling/parser-performance",
+    "dirty": false,
+    "statusShort": []
+  },
+  "corpus": {
+    "directory": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/luascripts",
+    "relativeDirectory": "luascripts"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=current hot-lua-suite",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-latest-hot.json",
+    "--no-fail-fast",
+    "-c",
+    "strings",
+    "-c",
+    "test/api",
+    "-c",
+    "test/files",
+    "-c",
+    "test/math",
+    "-c",
+    "test/db",
+    "-c",
+    "test/locals",
+    "-c",
+    "test/code",
+    "-c",
+    "test/pm",
+    "-c",
+    "test/strings",
+    "--corpus=luascripts"
+  ],
+  "rows": [
+    {
+      "case": "strings",
+      "path": "luascripts/strings.lua",
+      "source": {
+        "characters": 18253,
+        "lines": 518,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        18472,
+        17930,
+        12436,
+        11284,
+        11453,
+        9688,
+        9799,
+        10149,
+        13018,
+        13674
+      ],
+      "minMicros": 9688,
+      "meanMicros": 12790.3,
+      "medianMicros": 11944.5,
+      "maxMicros": 18472,
+      "charsPerSecond": 1427097.0970188347
+    },
+    {
+      "case": "test/api",
+      "path": "luascripts/test/api.lua",
+      "source": {
+        "characters": 40029,
+        "lines": 1417,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        27923,
+        32671,
+        20732,
+        18205,
+        14614,
+        14492,
+        13046,
+        13297,
+        15177,
+        14129
+      ],
+      "minMicros": 13046,
+      "meanMicros": 18428.6,
+      "medianMicros": 14895.5,
+      "maxMicros": 32671,
+      "charsPerSecond": 2172112.9114528503
+    },
+    {
+      "case": "test/code",
+      "path": "luascripts/test/code.lua",
+      "source": {
+        "characters": 14715,
+        "lines": 505,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        6723,
+        7401,
+        6875,
+        8098,
+        7219,
+        7538,
+        6412,
+        6390,
+        7587,
+        6538
+      ],
+      "minMicros": 6390,
+      "meanMicros": 7078.1,
+      "medianMicros": 7047.0,
+      "maxMicros": 8098,
+      "charsPerSecond": 2078947.7402127688
+    },
+    {
+      "case": "test/db",
+      "path": "luascripts/test/db.lua",
+      "source": {
+        "characters": 26597,
+        "lines": 1066,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        10898,
+        9449,
+        9187,
+        8871,
+        9315,
+        8336,
+        8626,
+        8685,
+        8716,
+        10010
+      ],
+      "minMicros": 8336,
+      "meanMicros": 9209.3,
+      "medianMicros": 9029.0,
+      "maxMicros": 10898,
+      "charsPerSecond": 2888058.8101158612
+    },
+    {
+      "case": "test/files",
+      "path": "luascripts/test/files.lua",
+      "source": {
+        "characters": 28151,
+        "lines": 1011,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        9087,
+        10286,
+        8495,
+        8501,
+        8961,
+        8582,
+        9564,
+        8436,
+        10172,
+        8329
+      ],
+      "minMicros": 8329,
+      "meanMicros": 9041.3,
+      "medianMicros": 8771.5,
+      "maxMicros": 10286,
+      "charsPerSecond": 3113600.92022165
+    },
+    {
+      "case": "test/locals",
+      "path": "luascripts/test/locals.lua",
+      "source": {
+        "characters": 30652,
+        "lines": 1228,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        8206,
+        8152,
+        9692,
+        7592,
+        8369,
+        8073,
+        9082,
+        7807,
+        8455,
+        8168
+      ],
+      "minMicros": 7592,
+      "meanMicros": 8359.6,
+      "medianMicros": 8187.0,
+      "maxMicros": 9692,
+      "charsPerSecond": 3666682.616393129
+    },
+    {
+      "case": "test/math",
+      "path": "luascripts/test/math.lua",
+      "source": {
+        "characters": 33144,
+        "lines": 1146,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        11640,
+        11922,
+        10608,
+        14047,
+        12079,
+        10816,
+        10744,
+        10835,
+        10411,
+        11745
+      ],
+      "minMicros": 10411,
+      "meanMicros": 11484.7,
+      "medianMicros": 11237.5,
+      "maxMicros": 14047,
+      "charsPerSecond": 2885926.493508755
+    },
+    {
+      "case": "test/pm",
+      "path": "luascripts/test/pm.lua",
+      "source": {
+        "characters": 13818,
+        "lines": 443,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        4190,
+        4162,
+        4694,
+        4128,
+        4542,
+        3919,
+        4402,
+        5691,
+        4319,
+        4390
+      ],
+      "minMicros": 3919,
+      "meanMicros": 4443.7,
+      "medianMicros": 4354.5,
+      "maxMicros": 5691,
+      "charsPerSecond": 3109570.853117897
+    },
+    {
+      "case": "test/strings",
+      "path": "luascripts/test/strings.lua",
+      "source": {
+        "characters": 19405,
+        "lines": 564,
+        "encoding": "latin1"
+      },
+      "samplesMicros": [
+        5523,
+        5864,
+        5731,
+        7201,
+        7298,
+        5580,
+        5671,
+        6564,
+        6979,
+        9193
+      ],
+      "minMicros": 5523,
+      "meanMicros": 6560.4,
+      "medianMicros": 6214.0,
+      "maxMicros": 9193,
+      "charsPerSecond": 2957898.908603134
+    }
+  ],
+  "total": {
+    "meanMicros": 87396.0,
+    "meanMs": 87.396
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-latest-small.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-latest-small.json
@@ -1,0 +1,195 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T09:19:40.305093",
+  "label": "current small-parser-corpus",
+  "packageRoot": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike",
+  "git": {
+    "revision": "a85d083aee335b3963edc70da5de78296c0a7caa",
+    "branch": "profiling/parser-performance",
+    "dirty": false,
+    "statusShort": []
+  },
+  "corpus": {
+    "directory": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/luascripts/parser_profiles",
+    "relativeDirectory": "luascripts/parser_profiles"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=current small-parser-corpus",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T09-19-29-latest-small.json",
+    "--no-fail-fast"
+  ],
+  "rows": [
+    {
+      "case": "attributes_and_labels",
+      "path": "luascripts/parser_profiles/attributes_and_labels.lua",
+      "source": {
+        "characters": 122,
+        "lines": 11,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        1037,
+        910,
+        1259,
+        888,
+        813,
+        1403,
+        902,
+        1074,
+        931,
+        801
+      ],
+      "minMicros": 801,
+      "meanMicros": 1001.8,
+      "medianMicros": 920.5,
+      "maxMicros": 1403,
+      "charsPerSecond": 121780.79456977441
+    },
+    {
+      "case": "branches_and_loops",
+      "path": "luascripts/parser_profiles/branches_and_loops.lua",
+      "source": {
+        "characters": 263,
+        "lines": 22,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        1095,
+        1065,
+        1192,
+        1406,
+        876,
+        809,
+        780,
+        782,
+        1453,
+        870
+      ],
+      "minMicros": 780,
+      "meanMicros": 1032.8,
+      "medianMicros": 970.5,
+      "maxMicros": 1453,
+      "charsPerSecond": 254647.56003098373
+    },
+    {
+      "case": "functions_and_calls",
+      "path": "luascripts/parser_profiles/functions_and_calls.lua",
+      "source": {
+        "characters": 261,
+        "lines": 15,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        681,
+        1087,
+        825,
+        769,
+        692,
+        732,
+        432,
+        458,
+        428,
+        450
+      ],
+      "minMicros": 428,
+      "meanMicros": 655.4,
+      "medianMicros": 686.5,
+      "maxMicros": 1087,
+      "charsPerSecond": 398230.08849557524
+    },
+    {
+      "case": "literals_and_expressions",
+      "path": "luascripts/parser_profiles/literals_and_expressions.lua",
+      "source": {
+        "characters": 152,
+        "lines": 6,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        378,
+        629,
+        417,
+        497,
+        414,
+        418,
+        543,
+        449,
+        524,
+        493
+      ],
+      "minMicros": 378,
+      "meanMicros": 476.2,
+      "medianMicros": 471.0,
+      "maxMicros": 629,
+      "charsPerSecond": 319193.61612767744
+    },
+    {
+      "case": "strings_and_comments",
+      "path": "luascripts/parser_profiles/strings_and_comments.lua",
+      "source": {
+        "characters": 254,
+        "lines": 13,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        318,
+        297,
+        282,
+        196,
+        241,
+        207,
+        210,
+        219,
+        212,
+        210
+      ],
+      "minMicros": 196,
+      "meanMicros": 239.2,
+      "medianMicros": 215.5,
+      "maxMicros": 318,
+      "charsPerSecond": 1061872.9096989967
+    },
+    {
+      "case": "table_shapes",
+      "path": "luascripts/parser_profiles/table_shapes.lua",
+      "source": {
+        "characters": 233,
+        "lines": 12,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        590,
+        804,
+        581,
+        483,
+        738,
+        479,
+        790,
+        682,
+        682,
+        642
+      ],
+      "minMicros": 479,
+      "meanMicros": 647.1,
+      "medianMicros": 662.0,
+      "maxMicros": 804,
+      "charsPerSecond": 360067.9956730026
+    }
+  ],
+  "total": {
+    "meanMicros": 4052.4999999999995,
+    "meanMs": 4.052499999999999
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-baseline-hot.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-baseline-hot.json
@@ -1,0 +1,297 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T10:24:58.001915",
+  "label": "origin/ir hot-lua-suite",
+  "packageRoot": "/tmp/lualike-parser-baseline.TLDRFH/pkgs/lualike",
+  "git": {
+    "revision": "9fddd67a706a26d441e360f9a1508744e9cb41fc",
+    "branch": null,
+    "dirty": true,
+    "statusShort": [
+      "M ../../pubspec.lock",
+      "?? luascripts/parser_profiles/",
+      "?? tool/parser_profile.dart",
+      "?? tool/parser_profile_compare.dart"
+    ]
+  },
+  "corpus": {
+    "directory": "/tmp/lualike-parser-baseline.TLDRFH/pkgs/lualike/luascripts",
+    "relativeDirectory": "luascripts"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=origin/ir hot-lua-suite",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-baseline-hot.json",
+    "--no-fail-fast",
+    "-c",
+    "strings",
+    "-c",
+    "test/api",
+    "-c",
+    "test/files",
+    "-c",
+    "test/math",
+    "-c",
+    "test/db",
+    "-c",
+    "test/locals",
+    "-c",
+    "test/code",
+    "-c",
+    "test/pm",
+    "-c",
+    "test/strings",
+    "--corpus=luascripts"
+  ],
+  "rows": [
+    {
+      "case": "strings",
+      "path": "luascripts/strings.lua",
+      "source": {
+        "characters": 18253,
+        "lines": 518,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        619848,
+        553137,
+        714507,
+        744288,
+        586998,
+        530924,
+        512194,
+        485904,
+        502866,
+        501378
+      ],
+      "minMicros": 485904,
+      "meanMicros": 575204.4,
+      "medianMicros": 542030.5,
+      "maxMicros": 744288,
+      "charsPerSecond": 31733.067410471824
+    },
+    {
+      "case": "test/api",
+      "path": "luascripts/test/api.lua",
+      "source": {
+        "characters": 40029,
+        "lines": 1417,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        370108,
+        360554,
+        287574,
+        316788,
+        335425,
+        374177,
+        420181,
+        342517,
+        540166,
+        420901
+      ],
+      "minMicros": 287574,
+      "meanMicros": 376839.1,
+      "medianMicros": 365331.0,
+      "maxMicros": 540166,
+      "charsPerSecond": 106223.05381792919
+    },
+    {
+      "case": "test/code",
+      "path": "luascripts/test/code.lua",
+      "source": {
+        "characters": 14715,
+        "lines": 505,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        241143,
+        245316,
+        221196,
+        212479,
+        218264,
+        204431,
+        215908,
+        237389,
+        269587,
+        272758
+      ],
+      "minMicros": 204431,
+      "meanMicros": 233847.1,
+      "medianMicros": 229292.5,
+      "maxMicros": 272758,
+      "charsPerSecond": 62925.73224128073
+    },
+    {
+      "case": "test/db",
+      "path": "luascripts/test/db.lua",
+      "source": {
+        "characters": 26597,
+        "lines": 1066,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        377417,
+        278688,
+        291836,
+        344831,
+        360503,
+        490353,
+        521009,
+        340675,
+        273314,
+        406544
+      ],
+      "minMicros": 273314,
+      "meanMicros": 368517.0,
+      "medianMicros": 352667.0,
+      "maxMicros": 521009,
+      "charsPerSecond": 72173.06121562913
+    },
+    {
+      "case": "test/files",
+      "path": "luascripts/test/files.lua",
+      "source": {
+        "characters": 28151,
+        "lines": 1011,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        442809,
+        426043,
+        337305,
+        312364,
+        283017,
+        286813,
+        287511,
+        275320,
+        285088,
+        278542
+      ],
+      "minMicros": 275320,
+      "meanMicros": 321481.2,
+      "medianMicros": 287162.0,
+      "maxMicros": 442809,
+      "charsPerSecond": 87566.55132555185
+    },
+    {
+      "case": "test/locals",
+      "path": "luascripts/test/locals.lua",
+      "source": {
+        "characters": 30652,
+        "lines": 1228,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        137113,
+        140643,
+        170609,
+        168172,
+        193526,
+        169985,
+        173027,
+        158912,
+        164528,
+        165497
+      ],
+      "minMicros": 137113,
+      "meanMicros": 164201.2,
+      "medianMicros": 166834.5,
+      "maxMicros": 193526,
+      "charsPerSecond": 186673.4226059249
+    },
+    {
+      "case": "test/math",
+      "path": "luascripts/test/math.lua",
+      "source": {
+        "characters": 33144,
+        "lines": 1146,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        222919,
+        230714,
+        233676,
+        233493,
+        245283,
+        329127,
+        329638,
+        311658,
+        300201,
+        246579
+      ],
+      "minMicros": 222919,
+      "meanMicros": 268328.8,
+      "medianMicros": 245931.0,
+      "maxMicros": 329638,
+      "charsPerSecond": 123520.09922155208
+    },
+    {
+      "case": "test/pm",
+      "path": "luascripts/test/pm.lua",
+      "source": {
+        "characters": 13818,
+        "lines": 443,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        283779,
+        275711,
+        253659,
+        274912,
+        345285,
+        286934,
+        288171,
+        297437,
+        313937,
+        280953
+      ],
+      "minMicros": 253659,
+      "meanMicros": 290077.8,
+      "medianMicros": 285356.5,
+      "maxMicros": 345285,
+      "charsPerSecond": 47635.49640820497
+    },
+    {
+      "case": "test/strings",
+      "path": "luascripts/test/strings.lua",
+      "source": {
+        "characters": 19405,
+        "lines": 564,
+        "encoding": "latin1"
+      },
+      "samplesMicros": [
+        332151,
+        328957,
+        325000,
+        424059,
+        528417,
+        588905,
+        870696,
+        924375,
+        679310,
+        696146
+      ],
+      "minMicros": 325000,
+      "meanMicros": 569801.6,
+      "medianMicros": 558661.0,
+      "maxMicros": 924375,
+      "charsPerSecond": 34055.71342727012
+    }
+  ],
+  "total": {
+    "meanMicros": 3168298.1999999997,
+    "meanMs": 3168.2981999999997
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-baseline-small.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-baseline-small.json
@@ -1,0 +1,200 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T10:24:01.905949",
+  "label": "origin/ir small-parser-corpus",
+  "packageRoot": "/tmp/lualike-parser-baseline.TLDRFH/pkgs/lualike",
+  "git": {
+    "revision": "9fddd67a706a26d441e360f9a1508744e9cb41fc",
+    "branch": null,
+    "dirty": true,
+    "statusShort": [
+      "M ../../pubspec.lock",
+      "?? luascripts/parser_profiles/",
+      "?? tool/parser_profile.dart",
+      "?? tool/parser_profile_compare.dart"
+    ]
+  },
+  "corpus": {
+    "directory": "/tmp/lualike-parser-baseline.TLDRFH/pkgs/lualike/luascripts/parser_profiles",
+    "relativeDirectory": "luascripts/parser_profiles"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=origin/ir small-parser-corpus",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-baseline-small.json",
+    "--no-fail-fast"
+  ],
+  "rows": [
+    {
+      "case": "attributes_and_labels",
+      "path": "luascripts/parser_profiles/attributes_and_labels.lua",
+      "source": {
+        "characters": 122,
+        "lines": 11,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        2110,
+        1596,
+        3210,
+        1611,
+        1510,
+        1679,
+        1770,
+        1558,
+        1581,
+        1539
+      ],
+      "minMicros": 1510,
+      "meanMicros": 1816.4,
+      "medianMicros": 1603.5,
+      "maxMicros": 3210,
+      "charsPerSecond": 67165.82250605593
+    },
+    {
+      "case": "branches_and_loops",
+      "path": "luascripts/parser_profiles/branches_and_loops.lua",
+      "source": {
+        "characters": 263,
+        "lines": 22,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        2156,
+        1898,
+        1678,
+        1608,
+        1381,
+        1674,
+        1268,
+        1236,
+        1386,
+        1386
+      ],
+      "minMicros": 1236,
+      "meanMicros": 1567.1,
+      "medianMicros": 1497.0,
+      "maxMicros": 2156,
+      "charsPerSecond": 167825.92049007723
+    },
+    {
+      "case": "functions_and_calls",
+      "path": "luascripts/parser_profiles/functions_and_calls.lua",
+      "source": {
+        "characters": 261,
+        "lines": 15,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        950,
+        872,
+        846,
+        830,
+        896,
+        1418,
+        964,
+        919,
+        1843,
+        837
+      ],
+      "minMicros": 830,
+      "meanMicros": 1037.5,
+      "medianMicros": 907.5,
+      "maxMicros": 1843,
+      "charsPerSecond": 251566.26506024096
+    },
+    {
+      "case": "literals_and_expressions",
+      "path": "luascripts/parser_profiles/literals_and_expressions.lua",
+      "source": {
+        "characters": 152,
+        "lines": 6,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        773,
+        1147,
+        1006,
+        768,
+        830,
+        941,
+        933,
+        986,
+        628,
+        615
+      ],
+      "minMicros": 615,
+      "meanMicros": 862.7,
+      "medianMicros": 881.5,
+      "maxMicros": 1147,
+      "charsPerSecond": 176191.02816738145
+    },
+    {
+      "case": "strings_and_comments",
+      "path": "luascripts/parser_profiles/strings_and_comments.lua",
+      "source": {
+        "characters": 254,
+        "lines": 13,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        2771,
+        3108,
+        2765,
+        2625,
+        2586,
+        2473,
+        2854,
+        2593,
+        1909,
+        2260
+      ],
+      "minMicros": 1909,
+      "meanMicros": 2594.4,
+      "medianMicros": 2609.0,
+      "maxMicros": 3108,
+      "charsPerSecond": 97903.17607153869
+    },
+    {
+      "case": "table_shapes",
+      "path": "luascripts/parser_profiles/table_shapes.lua",
+      "source": {
+        "characters": 233,
+        "lines": 12,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        4874,
+        5068,
+        3950,
+        3668,
+        3498,
+        3498,
+        3491,
+        4176,
+        2062,
+        2228
+      ],
+      "minMicros": 2062,
+      "meanMicros": 3651.3,
+      "medianMicros": 3583.0,
+      "maxMicros": 5068,
+      "charsPerSecond": 63812.88856023882
+    }
+  ],
+  "total": {
+    "meanMicros": 11529.400000000001,
+    "meanMs": 11.5294
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-comparison-hot.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-comparison-hot.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile_compare.dart",
+  "title": "Hot Lua Suite",
+  "generatedAt": "2026-05-03T10:25:04.949358",
+  "baseline": {
+    "label": "origin/ir hot-lua-suite",
+    "capturedAt": "2026-05-03T10:24:58.001915",
+    "revision": "9fddd67a706a26d441e360f9a1508744e9cb41fc",
+    "branch": null
+  },
+  "latest": {
+    "label": "current hot-lua-suite",
+    "capturedAt": "2026-05-03T10:25:04.139547",
+    "revision": "2e71bc07415ff9dec381ada038ea246e3eb16d39",
+    "branch": "profiling/parser-performance"
+  },
+  "rows": [
+    {
+      "case": "strings",
+      "baselineMeanMicros": 575204.4,
+      "latestMeanMicros": 13017.0,
+      "timeReductionPercent": 97.73697836803751,
+      "speedup": 44.18870707536299
+    },
+    {
+      "case": "test/api",
+      "baselineMeanMicros": 376839.1,
+      "latestMeanMicros": 18696.8,
+      "timeReductionPercent": 95.03851909210059,
+      "speedup": 20.155272560010268
+    },
+    {
+      "case": "test/code",
+      "baselineMeanMicros": 233847.1,
+      "latestMeanMicros": 6944.0,
+      "timeReductionPercent": 97.03053833038767,
+      "speedup": 33.67613767281106
+    },
+    {
+      "case": "test/db",
+      "baselineMeanMicros": 368517.0,
+      "latestMeanMicros": 9801.8,
+      "timeReductionPercent": 97.34020411541394,
+      "speedup": 37.59686996265992
+    },
+    {
+      "case": "test/files",
+      "baselineMeanMicros": 321481.2,
+      "latestMeanMicros": 13254.6,
+      "timeReductionPercent": 95.87702173564116,
+      "speedup": 24.254311710651397
+    },
+    {
+      "case": "test/locals",
+      "baselineMeanMicros": 164201.2,
+      "latestMeanMicros": 11791.7,
+      "timeReductionPercent": 92.81874919306314,
+      "speedup": 13.925150741623346
+    },
+    {
+      "case": "test/math",
+      "baselineMeanMicros": 268328.8,
+      "latestMeanMicros": 27093.8,
+      "timeReductionPercent": 89.90276109012525,
+      "speedup": 9.903697524894994
+    },
+    {
+      "case": "test/pm",
+      "baselineMeanMicros": 290077.8,
+      "latestMeanMicros": 7348.7,
+      "timeReductionPercent": 97.46664515519629,
+      "speedup": 39.47334902771919
+    },
+    {
+      "case": "test/strings",
+      "baselineMeanMicros": 569801.6,
+      "latestMeanMicros": 8803.8,
+      "timeReductionPercent": 98.45493589347589,
+      "speedup": 64.72223358095368
+    }
+  ],
+  "total": {
+    "baselineMeanMicros": 3168298.1999999997,
+    "latestMeanMicros": 116752.20000000001,
+    "timeReductionPercent": 96.31498701732052,
+    "speedup": 27.13694645582695
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-comparison-hot.md
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-comparison-hot.md
@@ -1,0 +1,26 @@
+# Hot Lua Suite
+
+Generated: `2026-05-03T10:25:04.949358`
+
+Baseline: `origin/ir hot-lua-suite`, revision `9fddd67a706a`, captured `2026-05-03T10:24:58.001915`
+
+Latest: `current hot-lua-suite`, revision `2e71bc07415f`, branch `profiling/parser-performance`, captured `2026-05-03T10:25:04.139547`
+
+Percentage improvement is mean parse-time reduction:
+
+```text
+(baseline mean - latest mean) / baseline mean
+```
+
+| Case | Baseline | Latest | Reduction | Speedup |
+| --- | ---: | ---: | ---: | ---: |
+| `strings` | `575.204 ms` | `13.017 ms` | `97.7%` | `44.2x` |
+| `test/api` | `376.839 ms` | `18.697 ms` | `95.0%` | `20.2x` |
+| `test/code` | `233.847 ms` | `6.944 ms` | `97.0%` | `33.7x` |
+| `test/db` | `368.517 ms` | `9.802 ms` | `97.3%` | `37.6x` |
+| `test/files` | `321.481 ms` | `13.255 ms` | `95.9%` | `24.3x` |
+| `test/locals` | `164.201 ms` | `11.792 ms` | `92.8%` | `13.9x` |
+| `test/math` | `268.329 ms` | `27.094 ms` | `89.9%` | `9.9x` |
+| `test/pm` | `290.078 ms` | `7.349 ms` | `97.5%` | `39.5x` |
+| `test/strings` | `569.802 ms` | `8.804 ms` | `98.5%` | `64.7x` |
+| **Total** | `3168.298 ms` | `116.752 ms` | **`96.3%`** | **`27.1x`** |

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-comparison-small.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-comparison-small.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile_compare.dart",
+  "title": "Small Parser Corpus",
+  "generatedAt": "2026-05-03T10:24:06.576844",
+  "baseline": {
+    "label": "origin/ir small-parser-corpus",
+    "capturedAt": "2026-05-03T10:24:01.905949",
+    "revision": "9fddd67a706a26d441e360f9a1508744e9cb41fc",
+    "branch": null
+  },
+  "latest": {
+    "label": "current small-parser-corpus",
+    "capturedAt": "2026-05-03T10:24:05.876652",
+    "revision": "2e71bc07415ff9dec381ada038ea246e3eb16d39",
+    "branch": "profiling/parser-performance"
+  },
+  "rows": [
+    {
+      "case": "attributes_and_labels",
+      "baselineMeanMicros": 1816.4,
+      "latestMeanMicros": 1121.1,
+      "timeReductionPercent": 38.27901343316451,
+      "speedup": 1.6201944518776203
+    },
+    {
+      "case": "branches_and_loops",
+      "baselineMeanMicros": 1567.1,
+      "latestMeanMicros": 1358.9,
+      "timeReductionPercent": 13.285686937655532,
+      "speedup": 1.1532121568916034
+    },
+    {
+      "case": "functions_and_calls",
+      "baselineMeanMicros": 1037.5,
+      "latestMeanMicros": 671.7,
+      "timeReductionPercent": 35.2578313253012,
+      "speedup": 1.544588357897871
+    },
+    {
+      "case": "literals_and_expressions",
+      "baselineMeanMicros": 862.7,
+      "latestMeanMicros": 412.2,
+      "timeReductionPercent": 52.219775124608795,
+      "speedup": 2.092916060164969
+    },
+    {
+      "case": "strings_and_comments",
+      "baselineMeanMicros": 2594.4,
+      "latestMeanMicros": 293.4,
+      "timeReductionPercent": 88.69102682701202,
+      "speedup": 8.842535787321065
+    },
+    {
+      "case": "table_shapes",
+      "baselineMeanMicros": 3651.3,
+      "latestMeanMicros": 616.9,
+      "timeReductionPercent": 83.10464765973762,
+      "speedup": 5.918787485816178
+    }
+  ],
+  "total": {
+    "baselineMeanMicros": 11529.400000000001,
+    "latestMeanMicros": 4474.2,
+    "timeReductionPercent": 61.19312366645272,
+    "speedup": 2.576862902865317
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-comparison-small.md
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-comparison-small.md
@@ -1,0 +1,23 @@
+# Small Parser Corpus
+
+Generated: `2026-05-03T10:24:06.576844`
+
+Baseline: `origin/ir small-parser-corpus`, revision `9fddd67a706a`, captured `2026-05-03T10:24:01.905949`
+
+Latest: `current small-parser-corpus`, revision `2e71bc07415f`, branch `profiling/parser-performance`, captured `2026-05-03T10:24:05.876652`
+
+Percentage improvement is mean parse-time reduction:
+
+```text
+(baseline mean - latest mean) / baseline mean
+```
+
+| Case | Baseline | Latest | Reduction | Speedup |
+| --- | ---: | ---: | ---: | ---: |
+| `attributes_and_labels` | `1.816 ms` | `1.121 ms` | `38.3%` | `1.6x` |
+| `branches_and_loops` | `1.567 ms` | `1.359 ms` | `13.3%` | `1.2x` |
+| `functions_and_calls` | `1.038 ms` | `0.672 ms` | `35.3%` | `1.5x` |
+| `literals_and_expressions` | `0.863 ms` | `0.412 ms` | `52.2%` | `2.1x` |
+| `strings_and_comments` | `2.594 ms` | `0.293 ms` | `88.7%` | `8.8x` |
+| `table_shapes` | `3.651 ms` | `0.617 ms` | `83.1%` | `5.9x` |
+| **Total** | `11.529 ms` | `4.474 ms` | **`61.2%`** | **`2.6x`** |

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-latest-hot.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-latest-hot.json
@@ -1,0 +1,299 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T10:25:04.139547",
+  "label": "current hot-lua-suite",
+  "packageRoot": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike",
+  "git": {
+    "revision": "2e71bc07415ff9dec381ada038ea246e3eb16d39",
+    "branch": "profiling/parser-performance",
+    "dirty": true,
+    "statusShort": [
+      "M ../../pubspec.lock",
+      "?? benchmarks/parser_profiles/2026-05-03T10-23-55-baseline-hot.json",
+      "?? benchmarks/parser_profiles/2026-05-03T10-23-55-baseline-small.json",
+      "?? benchmarks/parser_profiles/2026-05-03T10-23-55-comparison-small.json",
+      "?? benchmarks/parser_profiles/2026-05-03T10-23-55-comparison-small.md",
+      "?? benchmarks/parser_profiles/2026-05-03T10-23-55-latest-small.json"
+    ]
+  },
+  "corpus": {
+    "directory": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/luascripts",
+    "relativeDirectory": "luascripts"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=current hot-lua-suite",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-latest-hot.json",
+    "--no-fail-fast",
+    "-c",
+    "strings",
+    "-c",
+    "test/api",
+    "-c",
+    "test/files",
+    "-c",
+    "test/math",
+    "-c",
+    "test/db",
+    "-c",
+    "test/locals",
+    "-c",
+    "test/code",
+    "-c",
+    "test/pm",
+    "-c",
+    "test/strings",
+    "--corpus=luascripts"
+  ],
+  "rows": [
+    {
+      "case": "strings",
+      "path": "luascripts/strings.lua",
+      "source": {
+        "characters": 18253,
+        "lines": 518,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        13975,
+        15520,
+        15083,
+        12400,
+        12356,
+        11069,
+        15510,
+        11043,
+        10001,
+        13213
+      ],
+      "minMicros": 10001,
+      "meanMicros": 13017.0,
+      "medianMicros": 12806.5,
+      "maxMicros": 15520,
+      "charsPerSecond": 1402243.2204040869
+    },
+    {
+      "case": "test/api",
+      "path": "luascripts/test/api.lua",
+      "source": {
+        "characters": 40029,
+        "lines": 1417,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        17236,
+        18377,
+        14614,
+        23539,
+        21917,
+        16524,
+        18606,
+        22273,
+        21837,
+        12045
+      ],
+      "minMicros": 12045,
+      "meanMicros": 18696.8,
+      "medianMicros": 18491.5,
+      "maxMicros": 23539,
+      "charsPerSecond": 2140954.6018570024
+    },
+    {
+      "case": "test/code",
+      "path": "luascripts/test/code.lua",
+      "source": {
+        "characters": 14715,
+        "lines": 505,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        7386,
+        6600,
+        7010,
+        8338,
+        6848,
+        6310,
+        6586,
+        6593,
+        7051,
+        6718
+      ],
+      "minMicros": 6310,
+      "meanMicros": 6944.0,
+      "medianMicros": 6783.0,
+      "maxMicros": 8338,
+      "charsPerSecond": 2119095.6221198156
+    },
+    {
+      "case": "test/db",
+      "path": "luascripts/test/db.lua",
+      "source": {
+        "characters": 26597,
+        "lines": 1066,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        9751,
+        8832,
+        9234,
+        10074,
+        9308,
+        8624,
+        8518,
+        10164,
+        10138,
+        13375
+      ],
+      "minMicros": 8518,
+      "meanMicros": 9801.8,
+      "medianMicros": 9529.5,
+      "maxMicros": 13375,
+      "charsPerSecond": 2713481.1973311026
+    },
+    {
+      "case": "test/files",
+      "path": "luascripts/test/files.lua",
+      "source": {
+        "characters": 28151,
+        "lines": 1011,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        10566,
+        11293,
+        11534,
+        9403,
+        14145,
+        12363,
+        14658,
+        14849,
+        14188,
+        19547
+      ],
+      "minMicros": 9403,
+      "meanMicros": 13254.6,
+      "medianMicros": 13254.0,
+      "maxMicros": 19547,
+      "charsPerSecond": 2123866.431276689
+    },
+    {
+      "case": "test/locals",
+      "path": "luascripts/test/locals.lua",
+      "source": {
+        "characters": 30652,
+        "lines": 1228,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        13627,
+        15743,
+        11927,
+        8730,
+        9035,
+        10304,
+        10667,
+        11161,
+        12263,
+        14460
+      ],
+      "minMicros": 8730,
+      "meanMicros": 11791.7,
+      "medianMicros": 11544.0,
+      "maxMicros": 15743,
+      "charsPerSecond": 2599455.5492422637
+    },
+    {
+      "case": "test/math",
+      "path": "luascripts/test/math.lua",
+      "source": {
+        "characters": 33144,
+        "lines": 1146,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        21980,
+        28206,
+        20786,
+        33388,
+        37213,
+        27469,
+        23343,
+        27956,
+        28290,
+        22307
+      ],
+      "minMicros": 20786,
+      "meanMicros": 27093.8,
+      "medianMicros": 27712.5,
+      "maxMicros": 37213,
+      "charsPerSecond": 1223305.7009352695
+    },
+    {
+      "case": "test/pm",
+      "path": "luascripts/test/pm.lua",
+      "source": {
+        "characters": 13818,
+        "lines": 443,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        8590,
+        8639,
+        10045,
+        8107,
+        6436,
+        7092,
+        5343,
+        5378,
+        7523,
+        6334
+      ],
+      "minMicros": 5343,
+      "meanMicros": 7348.7,
+      "medianMicros": 7307.5,
+      "maxMicros": 10045,
+      "charsPerSecond": 1880332.5758297388
+    },
+    {
+      "case": "test/strings",
+      "path": "luascripts/test/strings.lua",
+      "source": {
+        "characters": 19405,
+        "lines": 564,
+        "encoding": "latin1"
+      },
+      "samplesMicros": [
+        7781,
+        10671,
+        11641,
+        10509,
+        9715,
+        8004,
+        7281,
+        7092,
+        7211,
+        8133
+      ],
+      "minMicros": 7092,
+      "meanMicros": 8803.8,
+      "medianMicros": 8068.5,
+      "maxMicros": 11641,
+      "charsPerSecond": 2204161.8392057978
+    }
+  ],
+  "total": {
+    "meanMicros": 116752.20000000001,
+    "meanMs": 116.75220000000002
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-latest-small.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-latest-small.json
@@ -1,0 +1,198 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T10:24:05.876652",
+  "label": "current small-parser-corpus",
+  "packageRoot": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike",
+  "git": {
+    "revision": "2e71bc07415ff9dec381ada038ea246e3eb16d39",
+    "branch": "profiling/parser-performance",
+    "dirty": true,
+    "statusShort": [
+      "M ../../pubspec.lock",
+      "?? benchmarks/parser_profiles/2026-05-03T10-23-55-baseline-small.json"
+    ]
+  },
+  "corpus": {
+    "directory": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/luascripts/parser_profiles",
+    "relativeDirectory": "luascripts/parser_profiles"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=current small-parser-corpus",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-23-55-latest-small.json",
+    "--no-fail-fast"
+  ],
+  "rows": [
+    {
+      "case": "attributes_and_labels",
+      "path": "luascripts/parser_profiles/attributes_and_labels.lua",
+      "source": {
+        "characters": 122,
+        "lines": 11,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        922,
+        811,
+        2552,
+        943,
+        937,
+        1012,
+        1626,
+        856,
+        793,
+        759
+      ],
+      "minMicros": 759,
+      "meanMicros": 1121.1,
+      "medianMicros": 929.5,
+      "maxMicros": 2552,
+      "charsPerSecond": 108821.69298010884
+    },
+    {
+      "case": "branches_and_loops",
+      "path": "luascripts/parser_profiles/branches_and_loops.lua",
+      "source": {
+        "characters": 263,
+        "lines": 22,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        1745,
+        1693,
+        1872,
+        1538,
+        1461,
+        1181,
+        1232,
+        1024,
+        927,
+        916
+      ],
+      "minMicros": 916,
+      "meanMicros": 1358.9,
+      "medianMicros": 1346.5,
+      "maxMicros": 1872,
+      "charsPerSecond": 193538.8917506807
+    },
+    {
+      "case": "functions_and_calls",
+      "path": "luascripts/parser_profiles/functions_and_calls.lua",
+      "source": {
+        "characters": 261,
+        "lines": 15,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        554,
+        951,
+        763,
+        822,
+        692,
+        734,
+        547,
+        506,
+        530,
+        618
+      ],
+      "minMicros": 506,
+      "meanMicros": 671.7,
+      "medianMicros": 655.0,
+      "maxMicros": 951,
+      "charsPerSecond": 388566.32425189816
+    },
+    {
+      "case": "literals_and_expressions",
+      "path": "luascripts/parser_profiles/literals_and_expressions.lua",
+      "source": {
+        "characters": 152,
+        "lines": 6,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        360,
+        368,
+        363,
+        359,
+        374,
+        458,
+        405,
+        358,
+        445,
+        632
+      ],
+      "minMicros": 358,
+      "meanMicros": 412.2,
+      "medianMicros": 371.0,
+      "maxMicros": 632,
+      "charsPerSecond": 368753.032508491
+    },
+    {
+      "case": "strings_and_comments",
+      "path": "luascripts/parser_profiles/strings_and_comments.lua",
+      "source": {
+        "characters": 254,
+        "lines": 13,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        211,
+        200,
+        203,
+        267,
+        318,
+        212,
+        199,
+        201,
+        647,
+        476
+      ],
+      "minMicros": 199,
+      "meanMicros": 293.4,
+      "medianMicros": 211.5,
+      "maxMicros": 647,
+      "charsPerSecond": 865712.3381049762
+    },
+    {
+      "case": "table_shapes",
+      "path": "luascripts/parser_profiles/table_shapes.lua",
+      "source": {
+        "characters": 233,
+        "lines": 12,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        727,
+        825,
+        663,
+        592,
+        473,
+        507,
+        646,
+        493,
+        431,
+        812
+      ],
+      "minMicros": 431,
+      "meanMicros": 616.9,
+      "medianMicros": 619.0,
+      "maxMicros": 825,
+      "charsPerSecond": 377694.92624412384
+    }
+  ],
+  "total": {
+    "meanMicros": 4474.2,
+    "meanMs": 4.4742
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-baseline-hot.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-baseline-hot.json
@@ -1,0 +1,297 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T10:53:47.773867",
+  "label": "origin/ir hot-lua-suite",
+  "packageRoot": "/tmp/lualike-parser-baseline.GFHYPZ/pkgs/lualike",
+  "git": {
+    "revision": "3f9069998692cf93cbc5461fe1d3e4150425a7ff",
+    "branch": null,
+    "dirty": true,
+    "statusShort": [
+      "M ../../pubspec.lock",
+      "?? luascripts/parser_profiles/",
+      "?? tool/parser_profile.dart",
+      "?? tool/parser_profile_compare.dart"
+    ]
+  },
+  "corpus": {
+    "directory": "/tmp/lualike-parser-baseline.GFHYPZ/pkgs/lualike/luascripts",
+    "relativeDirectory": "luascripts"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=origin/ir hot-lua-suite",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-baseline-hot.json",
+    "--no-fail-fast",
+    "-c",
+    "strings",
+    "-c",
+    "test/api",
+    "-c",
+    "test/files",
+    "-c",
+    "test/math",
+    "-c",
+    "test/db",
+    "-c",
+    "test/locals",
+    "-c",
+    "test/code",
+    "-c",
+    "test/pm",
+    "-c",
+    "test/strings",
+    "--corpus=luascripts"
+  ],
+  "rows": [
+    {
+      "case": "strings",
+      "path": "luascripts/strings.lua",
+      "source": {
+        "characters": 18253,
+        "lines": 518,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        598349,
+        527715,
+        789795,
+        917796,
+        1040211,
+        1001852,
+        983552,
+        961224,
+        832635,
+        990192
+      ],
+      "minMicros": 527715,
+      "meanMicros": 864332.1,
+      "medianMicros": 939510.0,
+      "maxMicros": 1040211,
+      "charsPerSecond": 21118.040160720633
+    },
+    {
+      "case": "test/api",
+      "path": "luascripts/test/api.lua",
+      "source": {
+        "characters": 40029,
+        "lines": 1417,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        328163,
+        346561,
+        363161,
+        363590,
+        322125,
+        310876,
+        304589,
+        326590,
+        349273,
+        354016
+      ],
+      "minMicros": 304589,
+      "meanMicros": 336894.4,
+      "medianMicros": 337362.0,
+      "maxMicros": 363590,
+      "charsPerSecond": 118817.64731025507
+    },
+    {
+      "case": "test/code",
+      "path": "luascripts/test/code.lua",
+      "source": {
+        "characters": 14715,
+        "lines": 505,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        532112,
+        501551,
+        545743,
+        426407,
+        552039,
+        469022,
+        583106,
+        632435,
+        482511,
+        450945
+      ],
+      "minMicros": 426407,
+      "meanMicros": 517587.1,
+      "medianMicros": 516831.5,
+      "maxMicros": 632435,
+      "charsPerSecond": 28429.997579151415
+    },
+    {
+      "case": "test/db",
+      "path": "luascripts/test/db.lua",
+      "source": {
+        "characters": 26597,
+        "lines": 1066,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        556015,
+        584728,
+        391824,
+        428916,
+        426812,
+        362850,
+        389013,
+        461102,
+        392545,
+        505858
+      ],
+      "minMicros": 362850,
+      "meanMicros": 449966.3,
+      "medianMicros": 427864.0,
+      "maxMicros": 584728,
+      "charsPerSecond": 59108.87104212027
+    },
+    {
+      "case": "test/files",
+      "path": "luascripts/test/files.lua",
+      "source": {
+        "characters": 28151,
+        "lines": 1011,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        732735,
+        694066,
+        700525,
+        764570,
+        609198,
+        613185,
+        626132,
+        611788,
+        507354,
+        611192
+      ],
+      "minMicros": 507354,
+      "meanMicros": 647074.5,
+      "medianMicros": 619658.5,
+      "maxMicros": 764570,
+      "charsPerSecond": 43505.036900696905
+    },
+    {
+      "case": "test/locals",
+      "path": "luascripts/test/locals.lua",
+      "source": {
+        "characters": 30652,
+        "lines": 1228,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        278819,
+        251882,
+        306337,
+        319768,
+        288096,
+        393351,
+        366796,
+        399747,
+        400509,
+        377778
+      ],
+      "minMicros": 251882,
+      "meanMicros": 338308.3,
+      "medianMicros": 343282.0,
+      "maxMicros": 400509,
+      "charsPerSecond": 90603.74811968846
+    },
+    {
+      "case": "test/math",
+      "path": "luascripts/test/math.lua",
+      "source": {
+        "characters": 33144,
+        "lines": 1146,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        522925,
+        601948,
+        661625,
+        552724,
+        481615,
+        476388,
+        509020,
+        445637,
+        454891,
+        607264
+      ],
+      "minMicros": 445637,
+      "meanMicros": 531403.7,
+      "medianMicros": 515972.5,
+      "maxMicros": 661625,
+      "charsPerSecond": 62370.66094948154
+    },
+    {
+      "case": "test/pm",
+      "path": "luascripts/test/pm.lua",
+      "source": {
+        "characters": 13818,
+        "lines": 443,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        847950,
+        779504,
+        672020,
+        641374,
+        702547,
+        657310,
+        532167,
+        751985,
+        714273,
+        839916
+      ],
+      "minMicros": 532167,
+      "meanMicros": 713904.6,
+      "medianMicros": 708410.0,
+      "maxMicros": 847950,
+      "charsPerSecond": 19355.527335164952
+    },
+    {
+      "case": "test/strings",
+      "path": "luascripts/test/strings.lua",
+      "source": {
+        "characters": 19405,
+        "lines": 564,
+        "encoding": "latin1"
+      },
+      "samplesMicros": [
+        742632,
+        727155,
+        576221,
+        539794,
+        549858,
+        590591,
+        578634,
+        538261,
+        710328,
+        680879
+      ],
+      "minMicros": 538261,
+      "meanMicros": 623435.3,
+      "medianMicros": 584612.5,
+      "maxMicros": 742632,
+      "charsPerSecond": 31125.924374189268
+    }
+  ],
+  "total": {
+    "meanMicros": 5022906.299999999,
+    "meanMs": 5022.906299999999
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-baseline-small.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-baseline-small.json
@@ -1,0 +1,200 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T10:52:21.336790",
+  "label": "origin/ir small-parser-corpus",
+  "packageRoot": "/tmp/lualike-parser-baseline.GFHYPZ/pkgs/lualike",
+  "git": {
+    "revision": "3f9069998692cf93cbc5461fe1d3e4150425a7ff",
+    "branch": null,
+    "dirty": true,
+    "statusShort": [
+      "M ../../pubspec.lock",
+      "?? luascripts/parser_profiles/",
+      "?? tool/parser_profile.dart",
+      "?? tool/parser_profile_compare.dart"
+    ]
+  },
+  "corpus": {
+    "directory": "/tmp/lualike-parser-baseline.GFHYPZ/pkgs/lualike/luascripts/parser_profiles",
+    "relativeDirectory": "luascripts/parser_profiles"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=origin/ir small-parser-corpus",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-baseline-small.json",
+    "--no-fail-fast"
+  ],
+  "rows": [
+    {
+      "case": "attributes_and_labels",
+      "path": "luascripts/parser_profiles/attributes_and_labels.lua",
+      "source": {
+        "characters": 122,
+        "lines": 11,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        3477,
+        3278,
+        4496,
+        3075,
+        4087,
+        2605,
+        3571,
+        3882,
+        4687,
+        2994
+      ],
+      "minMicros": 2605,
+      "meanMicros": 3615.2,
+      "medianMicros": 3524.0,
+      "maxMicros": 4687,
+      "charsPerSecond": 33746.40407169728
+    },
+    {
+      "case": "branches_and_loops",
+      "path": "luascripts/parser_profiles/branches_and_loops.lua",
+      "source": {
+        "characters": 263,
+        "lines": 22,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        2787,
+        2416,
+        1767,
+        1644,
+        2067,
+        1839,
+        2347,
+        1906,
+        2761,
+        2046
+      ],
+      "minMicros": 1644,
+      "meanMicros": 2158.0,
+      "medianMicros": 2056.5,
+      "maxMicros": 2787,
+      "charsPerSecond": 121872.10379981463
+    },
+    {
+      "case": "functions_and_calls",
+      "path": "luascripts/parser_profiles/functions_and_calls.lua",
+      "source": {
+        "characters": 261,
+        "lines": 15,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        2374,
+        1144,
+        1370,
+        1093,
+        1832,
+        1112,
+        1035,
+        1153,
+        1038,
+        1040
+      ],
+      "minMicros": 1035,
+      "meanMicros": 1319.1,
+      "medianMicros": 1128.0,
+      "maxMicros": 2374,
+      "charsPerSecond": 197862.17875824426
+    },
+    {
+      "case": "literals_and_expressions",
+      "path": "luascripts/parser_profiles/literals_and_expressions.lua",
+      "source": {
+        "characters": 152,
+        "lines": 6,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        1013,
+        1030,
+        836,
+        892,
+        844,
+        802,
+        702,
+        752,
+        726,
+        699
+      ],
+      "minMicros": 699,
+      "meanMicros": 829.6,
+      "medianMicros": 819.0,
+      "maxMicros": 1030,
+      "charsPerSecond": 183220.8293153327
+    },
+    {
+      "case": "strings_and_comments",
+      "path": "luascripts/parser_profiles/strings_and_comments.lua",
+      "source": {
+        "characters": 254,
+        "lines": 13,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        3211,
+        3934,
+        3399,
+        3754,
+        2800,
+        4136,
+        3022,
+        3081,
+        3030,
+        3018
+      ],
+      "minMicros": 2800,
+      "meanMicros": 3338.5,
+      "medianMicros": 3146.0,
+      "maxMicros": 4136,
+      "charsPerSecond": 76082.07278717987
+    },
+    {
+      "case": "table_shapes",
+      "path": "luascripts/parser_profiles/table_shapes.lua",
+      "source": {
+        "characters": 233,
+        "lines": 12,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        5246,
+        4832,
+        3839,
+        4062,
+        4012,
+        4079,
+        4032,
+        5628,
+        4001,
+        3852
+      ],
+      "minMicros": 3839,
+      "meanMicros": 4358.3,
+      "medianMicros": 4047.0,
+      "maxMicros": 5628,
+      "charsPerSecond": 53461.211940435496
+    }
+  ],
+  "total": {
+    "meanMicros": 15618.7,
+    "meanMs": 15.6187
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-comparison-hot.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-comparison-hot.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile_compare.dart",
+  "title": "Hot Lua Suite",
+  "generatedAt": "2026-05-03T10:53:56.913863",
+  "baseline": {
+    "label": "origin/ir hot-lua-suite",
+    "capturedAt": "2026-05-03T10:53:47.773867",
+    "revision": "3f9069998692cf93cbc5461fe1d3e4150425a7ff",
+    "branch": null
+  },
+  "latest": {
+    "label": "current hot-lua-suite",
+    "capturedAt": "2026-05-03T10:53:55.723995",
+    "revision": "ab37db12192ba4a3f93d98abd6552e4344a9f1a8",
+    "branch": "profiling/parser-performance"
+  },
+  "rows": [
+    {
+      "case": "strings",
+      "baselineMeanMicros": 864332.1,
+      "latestMeanMicros": 29349.2,
+      "timeReductionPercent": 96.60440703289858,
+      "speedup": 29.44993730663868
+    },
+    {
+      "case": "test/api",
+      "baselineMeanMicros": 336894.4,
+      "latestMeanMicros": 26844.7,
+      "timeReductionPercent": 92.03171676347246,
+      "speedup": 12.549754700182904
+    },
+    {
+      "case": "test/code",
+      "baselineMeanMicros": 517587.1,
+      "latestMeanMicros": 13350.1,
+      "timeReductionPercent": 97.42070465048299,
+      "speedup": 38.770278874315544
+    },
+    {
+      "case": "test/db",
+      "baselineMeanMicros": 449966.3,
+      "latestMeanMicros": 18092.5,
+      "timeReductionPercent": 95.97914332695582,
+      "speedup": 24.870321956611853
+    },
+    {
+      "case": "test/files",
+      "baselineMeanMicros": 647074.5,
+      "latestMeanMicros": 17993.8,
+      "timeReductionPercent": 97.21920737102141,
+      "speedup": 35.96096988962865
+    },
+    {
+      "case": "test/locals",
+      "baselineMeanMicros": 338308.3,
+      "latestMeanMicros": 11049.7,
+      "timeReductionPercent": 96.73383715386231,
+      "speedup": 30.616966976478995
+    },
+    {
+      "case": "test/math",
+      "baselineMeanMicros": 531403.7,
+      "latestMeanMicros": 17752.7,
+      "timeReductionPercent": 96.65928182284014,
+      "speedup": 29.933683327043205
+    },
+    {
+      "case": "test/pm",
+      "baselineMeanMicros": 713904.6,
+      "latestMeanMicros": 8866.0,
+      "timeReductionPercent": 98.75809737043298,
+      "speedup": 80.52161064741709
+    },
+    {
+      "case": "test/strings",
+      "baselineMeanMicros": 623435.3,
+      "latestMeanMicros": 12722.9,
+      "timeReductionPercent": 97.95922688368785,
+      "speedup": 49.00103749931227
+    }
+  ],
+  "total": {
+    "baselineMeanMicros": 5022906.299999999,
+    "latestMeanMicros": 156021.6,
+    "timeReductionPercent": 96.8937983175199,
+    "speedup": 32.1936597240382
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-comparison-hot.md
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-comparison-hot.md
@@ -1,0 +1,26 @@
+# Hot Lua Suite
+
+Generated: `2026-05-03T10:53:56.913863`
+
+Baseline: `origin/ir hot-lua-suite`, revision `3f9069998692`, captured `2026-05-03T10:53:47.773867`
+
+Latest: `current hot-lua-suite`, revision `ab37db12192b`, branch `profiling/parser-performance`, captured `2026-05-03T10:53:55.723995`
+
+Percentage improvement is mean parse-time reduction:
+
+```text
+(baseline mean - latest mean) / baseline mean
+```
+
+| Case | Baseline | Latest | Reduction | Speedup |
+| --- | ---: | ---: | ---: | ---: |
+| `strings` | `864.332 ms` | `29.349 ms` | `96.6%` | `29.4x` |
+| `test/api` | `336.894 ms` | `26.845 ms` | `92.0%` | `12.5x` |
+| `test/code` | `517.587 ms` | `13.350 ms` | `97.4%` | `38.8x` |
+| `test/db` | `449.966 ms` | `18.093 ms` | `96.0%` | `24.9x` |
+| `test/files` | `647.074 ms` | `17.994 ms` | `97.2%` | `36.0x` |
+| `test/locals` | `338.308 ms` | `11.050 ms` | `96.7%` | `30.6x` |
+| `test/math` | `531.404 ms` | `17.753 ms` | `96.7%` | `29.9x` |
+| `test/pm` | `713.905 ms` | `8.866 ms` | `98.8%` | `80.5x` |
+| `test/strings` | `623.435 ms` | `12.723 ms` | `98.0%` | `49.0x` |
+| **Total** | `5022.906 ms` | `156.022 ms` | **`96.9%`** | **`32.2x`** |

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-comparison-small.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-comparison-small.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile_compare.dart",
+  "title": "Small Parser Corpus",
+  "generatedAt": "2026-05-03T10:52:27.561531",
+  "baseline": {
+    "label": "origin/ir small-parser-corpus",
+    "capturedAt": "2026-05-03T10:52:21.336790",
+    "revision": "3f9069998692cf93cbc5461fe1d3e4150425a7ff",
+    "branch": null
+  },
+  "latest": {
+    "label": "current small-parser-corpus",
+    "capturedAt": "2026-05-03T10:52:26.679227",
+    "revision": "ab37db12192ba4a3f93d98abd6552e4344a9f1a8",
+    "branch": "profiling/parser-performance"
+  },
+  "rows": [
+    {
+      "case": "attributes_and_labels",
+      "baselineMeanMicros": 3615.2,
+      "latestMeanMicros": 1576.2,
+      "timeReductionPercent": 56.40075237884487,
+      "speedup": 2.293617561223195
+    },
+    {
+      "case": "branches_and_loops",
+      "baselineMeanMicros": 2158.0,
+      "latestMeanMicros": 2433.0,
+      "timeReductionPercent": -12.743280815569973,
+      "speedup": 0.886970817920263
+    },
+    {
+      "case": "functions_and_calls",
+      "baselineMeanMicros": 1319.1,
+      "latestMeanMicros": 944.1,
+      "timeReductionPercent": 28.428473959517845,
+      "speedup": 1.3972036860502064
+    },
+    {
+      "case": "literals_and_expressions",
+      "baselineMeanMicros": 829.6,
+      "latestMeanMicros": 526.0,
+      "timeReductionPercent": 36.59594985535198,
+      "speedup": 1.5771863117870724
+    },
+    {
+      "case": "strings_and_comments",
+      "baselineMeanMicros": 3338.5,
+      "latestMeanMicros": 321.8,
+      "timeReductionPercent": 90.36094054215965,
+      "speedup": 10.374456183965195
+    },
+    {
+      "case": "table_shapes",
+      "baselineMeanMicros": 4358.3,
+      "latestMeanMicros": 593.7,
+      "timeReductionPercent": 86.37771608195857,
+      "speedup": 7.340912918982651
+    }
+  ],
+  "total": {
+    "baselineMeanMicros": 15618.7,
+    "latestMeanMicros": 6394.8,
+    "timeReductionPercent": 59.05677169034555,
+    "speedup": 2.4424063301432413
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-comparison-small.md
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-comparison-small.md
@@ -1,0 +1,23 @@
+# Small Parser Corpus
+
+Generated: `2026-05-03T10:52:27.561531`
+
+Baseline: `origin/ir small-parser-corpus`, revision `3f9069998692`, captured `2026-05-03T10:52:21.336790`
+
+Latest: `current small-parser-corpus`, revision `ab37db12192b`, branch `profiling/parser-performance`, captured `2026-05-03T10:52:26.679227`
+
+Percentage improvement is mean parse-time reduction:
+
+```text
+(baseline mean - latest mean) / baseline mean
+```
+
+| Case | Baseline | Latest | Reduction | Speedup |
+| --- | ---: | ---: | ---: | ---: |
+| `attributes_and_labels` | `3.615 ms` | `1.576 ms` | `56.4%` | `2.3x` |
+| `branches_and_loops` | `2.158 ms` | `2.433 ms` | `-12.7%` | `0.9x` |
+| `functions_and_calls` | `1.319 ms` | `0.944 ms` | `28.4%` | `1.4x` |
+| `literals_and_expressions` | `0.830 ms` | `0.526 ms` | `36.6%` | `1.6x` |
+| `strings_and_comments` | `3.338 ms` | `0.322 ms` | `90.4%` | `10.4x` |
+| `table_shapes` | `4.358 ms` | `0.594 ms` | `86.4%` | `7.3x` |
+| **Total** | `15.619 ms` | `6.395 ms` | **`59.1%`** | **`2.4x`** |

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-latest-hot.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-latest-hot.json
@@ -1,0 +1,298 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T10:53:55.723995",
+  "label": "current hot-lua-suite",
+  "packageRoot": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike",
+  "git": {
+    "revision": "ab37db12192ba4a3f93d98abd6552e4344a9f1a8",
+    "branch": "profiling/parser-performance",
+    "dirty": true,
+    "statusShort": [
+      "?? benchmarks/parser_profiles/2026-05-03T10-52-14-baseline-hot.json",
+      "?? benchmarks/parser_profiles/2026-05-03T10-52-14-baseline-small.json",
+      "?? benchmarks/parser_profiles/2026-05-03T10-52-14-comparison-small.json",
+      "?? benchmarks/parser_profiles/2026-05-03T10-52-14-comparison-small.md",
+      "?? benchmarks/parser_profiles/2026-05-03T10-52-14-latest-small.json"
+    ]
+  },
+  "corpus": {
+    "directory": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/luascripts",
+    "relativeDirectory": "luascripts"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=current hot-lua-suite",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-latest-hot.json",
+    "--no-fail-fast",
+    "-c",
+    "strings",
+    "-c",
+    "test/api",
+    "-c",
+    "test/files",
+    "-c",
+    "test/math",
+    "-c",
+    "test/db",
+    "-c",
+    "test/locals",
+    "-c",
+    "test/code",
+    "-c",
+    "test/pm",
+    "-c",
+    "test/strings",
+    "--corpus=luascripts"
+  ],
+  "rows": [
+    {
+      "case": "strings",
+      "path": "luascripts/strings.lua",
+      "source": {
+        "characters": 18253,
+        "lines": 518,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        29595,
+        42264,
+        46868,
+        29676,
+        34120,
+        27704,
+        19398,
+        24867,
+        19254,
+        19746
+      ],
+      "minMicros": 19254,
+      "meanMicros": 29349.2,
+      "medianMicros": 28649.5,
+      "maxMicros": 46868,
+      "charsPerSecond": 621924.9587723004
+    },
+    {
+      "case": "test/api",
+      "path": "luascripts/test/api.lua",
+      "source": {
+        "characters": 40029,
+        "lines": 1417,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        24696,
+        27020,
+        21233,
+        31937,
+        54071,
+        40293,
+        18124,
+        15901,
+        17371,
+        17801
+      ],
+      "minMicros": 15901,
+      "meanMicros": 26844.7,
+      "medianMicros": 22964.5,
+      "maxMicros": 54071,
+      "charsPerSecond": 1491132.3277965484
+    },
+    {
+      "case": "test/code",
+      "path": "luascripts/test/code.lua",
+      "source": {
+        "characters": 14715,
+        "lines": 505,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        10677,
+        14006,
+        17750,
+        9134,
+        14641,
+        10634,
+        14891,
+        11571,
+        12195,
+        18002
+      ],
+      "minMicros": 9134,
+      "meanMicros": 13350.1,
+      "medianMicros": 13100.5,
+      "maxMicros": 18002,
+      "charsPerSecond": 1102238.934539816
+    },
+    {
+      "case": "test/db",
+      "path": "luascripts/test/db.lua",
+      "source": {
+        "characters": 26597,
+        "lines": 1066,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        12066,
+        15456,
+        15724,
+        17315,
+        16398,
+        18339,
+        15189,
+        16780,
+        18482,
+        35176
+      ],
+      "minMicros": 12066,
+      "meanMicros": 18092.5,
+      "medianMicros": 16589.0,
+      "maxMicros": 35176,
+      "charsPerSecond": 1470056.6533093823
+    },
+    {
+      "case": "test/files",
+      "path": "luascripts/test/files.lua",
+      "source": {
+        "characters": 28151,
+        "lines": 1011,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        28529,
+        21891,
+        29996,
+        19567,
+        12135,
+        15414,
+        13706,
+        13777,
+        13670,
+        11253
+      ],
+      "minMicros": 11253,
+      "meanMicros": 17993.8,
+      "medianMicros": 14595.5,
+      "maxMicros": 29996,
+      "charsPerSecond": 1564483.3220331448
+    },
+    {
+      "case": "test/locals",
+      "path": "luascripts/test/locals.lua",
+      "source": {
+        "characters": 30652,
+        "lines": 1228,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        13728,
+        15022,
+        10956,
+        9683,
+        9680,
+        11653,
+        9995,
+        8942,
+        10505,
+        10333
+      ],
+      "minMicros": 8942,
+      "meanMicros": 11049.7,
+      "medianMicros": 10419.0,
+      "maxMicros": 15022,
+      "charsPerSecond": 2774011.9641257226
+    },
+    {
+      "case": "test/math",
+      "path": "luascripts/test/math.lua",
+      "source": {
+        "characters": 33144,
+        "lines": 1146,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        22373,
+        18406,
+        13909,
+        16821,
+        22909,
+        21526,
+        20982,
+        14580,
+        13208,
+        12813
+      ],
+      "minMicros": 12813,
+      "meanMicros": 17752.7,
+      "medianMicros": 17613.5,
+      "maxMicros": 22909,
+      "charsPerSecond": 1866983.6137601605
+    },
+    {
+      "case": "test/pm",
+      "path": "luascripts/test/pm.lua",
+      "source": {
+        "characters": 13818,
+        "lines": 443,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        8658,
+        8481,
+        9345,
+        8942,
+        8366,
+        9394,
+        8694,
+        9566,
+        8476,
+        8738
+      ],
+      "minMicros": 8366,
+      "meanMicros": 8866.0,
+      "medianMicros": 8716.0,
+      "maxMicros": 9566,
+      "charsPerSecond": 1558538.2359575906
+    },
+    {
+      "case": "test/strings",
+      "path": "luascripts/test/strings.lua",
+      "source": {
+        "characters": 19405,
+        "lines": 564,
+        "encoding": "latin1"
+      },
+      "samplesMicros": [
+        12455,
+        12499,
+        13346,
+        12220,
+        12630,
+        12597,
+        12462,
+        12835,
+        13752,
+        12433
+      ],
+      "minMicros": 12220,
+      "meanMicros": 12722.9,
+      "medianMicros": 12548.0,
+      "maxMicros": 13752,
+      "charsPerSecond": 1525202.5874604061
+    }
+  ],
+  "total": {
+    "meanMicros": 156021.6,
+    "meanMs": 156.0216
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-latest-small.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-latest-small.json
@@ -1,0 +1,197 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T10:52:26.679227",
+  "label": "current small-parser-corpus",
+  "packageRoot": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike",
+  "git": {
+    "revision": "ab37db12192ba4a3f93d98abd6552e4344a9f1a8",
+    "branch": "profiling/parser-performance",
+    "dirty": true,
+    "statusShort": [
+      "?? benchmarks/parser_profiles/2026-05-03T10-52-14-baseline-small.json"
+    ]
+  },
+  "corpus": {
+    "directory": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/luascripts/parser_profiles",
+    "relativeDirectory": "luascripts/parser_profiles"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=current small-parser-corpus",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T10-52-14-latest-small.json",
+    "--no-fail-fast"
+  ],
+  "rows": [
+    {
+      "case": "attributes_and_labels",
+      "path": "luascripts/parser_profiles/attributes_and_labels.lua",
+      "source": {
+        "characters": 122,
+        "lines": 11,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        1857,
+        1437,
+        1410,
+        1391,
+        1386,
+        1423,
+        1414,
+        1398,
+        1389,
+        2657
+      ],
+      "minMicros": 1386,
+      "meanMicros": 1576.2,
+      "medianMicros": 1412.0,
+      "maxMicros": 2657,
+      "charsPerSecond": 77401.34500697881
+    },
+    {
+      "case": "branches_and_loops",
+      "path": "luascripts/parser_profiles/branches_and_loops.lua",
+      "source": {
+        "characters": 263,
+        "lines": 22,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        2490,
+        1923,
+        2181,
+        2009,
+        1652,
+        1517,
+        6673,
+        2328,
+        2231,
+        1326
+      ],
+      "minMicros": 1326,
+      "meanMicros": 2433.0,
+      "medianMicros": 2095.0,
+      "maxMicros": 6673,
+      "charsPerSecond": 108096.9995889848
+    },
+    {
+      "case": "functions_and_calls",
+      "path": "luascripts/parser_profiles/functions_and_calls.lua",
+      "source": {
+        "characters": 261,
+        "lines": 15,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        1044,
+        1106,
+        979,
+        861,
+        970,
+        913,
+        905,
+        887,
+        877,
+        899
+      ],
+      "minMicros": 861,
+      "meanMicros": 944.1,
+      "medianMicros": 909.0,
+      "maxMicros": 1106,
+      "charsPerSecond": 276453.76549094374
+    },
+    {
+      "case": "literals_and_expressions",
+      "path": "luascripts/parser_profiles/literals_and_expressions.lua",
+      "source": {
+        "characters": 152,
+        "lines": 6,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        485,
+        463,
+        435,
+        448,
+        809,
+        484,
+        518,
+        565,
+        479,
+        574
+      ],
+      "minMicros": 435,
+      "meanMicros": 526.0,
+      "medianMicros": 484.5,
+      "maxMicros": 809,
+      "charsPerSecond": 288973.38403041824
+    },
+    {
+      "case": "strings_and_comments",
+      "path": "luascripts/parser_profiles/strings_and_comments.lua",
+      "source": {
+        "characters": 254,
+        "lines": 13,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        289,
+        312,
+        294,
+        310,
+        261,
+        573,
+        376,
+        236,
+        311,
+        256
+      ],
+      "minMicros": 236,
+      "meanMicros": 321.8,
+      "medianMicros": 302.0,
+      "maxMicros": 573,
+      "charsPerSecond": 789310.1305158483
+    },
+    {
+      "case": "table_shapes",
+      "path": "luascripts/parser_profiles/table_shapes.lua",
+      "source": {
+        "characters": 233,
+        "lines": 12,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        557,
+        1149,
+        572,
+        569,
+        519,
+        489,
+        501,
+        484,
+        546,
+        551
+      ],
+      "minMicros": 484,
+      "meanMicros": 593.7,
+      "medianMicros": 548.5,
+      "maxMicros": 1149,
+      "charsPerSecond": 392454.1013980124
+    }
+  ],
+  "total": {
+    "meanMicros": 6394.8,
+    "meanMs": 6.3948
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-baseline-hot.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-baseline-hot.json
@@ -1,0 +1,297 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T11:02:02.979423",
+  "label": "origin/ir hot-lua-suite",
+  "packageRoot": "/tmp/lualike-parser-baseline.KGLNIO/pkgs/lualike",
+  "git": {
+    "revision": "3f9069998692cf93cbc5461fe1d3e4150425a7ff",
+    "branch": null,
+    "dirty": true,
+    "statusShort": [
+      "M ../../pubspec.lock",
+      "?? luascripts/parser_profiles/",
+      "?? tool/parser_profile.dart",
+      "?? tool/parser_profile_compare.dart"
+    ]
+  },
+  "corpus": {
+    "directory": "/tmp/lualike-parser-baseline.KGLNIO/pkgs/lualike/luascripts",
+    "relativeDirectory": "luascripts"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=origin/ir hot-lua-suite",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-baseline-hot.json",
+    "--no-fail-fast",
+    "-c",
+    "strings",
+    "-c",
+    "test/api",
+    "-c",
+    "test/files",
+    "-c",
+    "test/math",
+    "-c",
+    "test/db",
+    "-c",
+    "test/locals",
+    "-c",
+    "test/code",
+    "-c",
+    "test/pm",
+    "-c",
+    "test/strings",
+    "--corpus=luascripts"
+  ],
+  "rows": [
+    {
+      "case": "strings",
+      "path": "luascripts/strings.lua",
+      "source": {
+        "characters": 18253,
+        "lines": 518,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        585759,
+        709561,
+        676112,
+        645539,
+        665635,
+        732241,
+        657857,
+        712529,
+        599370,
+        579793
+      ],
+      "minMicros": 579793,
+      "meanMicros": 656439.6,
+      "medianMicros": 661746.0,
+      "maxMicros": 732241,
+      "charsPerSecond": 27806.06166964942
+    },
+    {
+      "case": "test/api",
+      "path": "luascripts/test/api.lua",
+      "source": {
+        "characters": 40029,
+        "lines": 1417,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        362992,
+        329273,
+        414952,
+        269273,
+        273922,
+        256351,
+        248597,
+        253047,
+        265458,
+        236670
+      ],
+      "minMicros": 236670,
+      "meanMicros": 291053.5,
+      "medianMicros": 267365.5,
+      "maxMicros": 414952,
+      "charsPerSecond": 137531.41604550366
+    },
+    {
+      "case": "test/code",
+      "path": "luascripts/test/code.lua",
+      "source": {
+        "characters": 14715,
+        "lines": 505,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        217140,
+        231721,
+        259934,
+        264700,
+        271305,
+        330806,
+        278259,
+        260278,
+        259371,
+        269517
+      ],
+      "minMicros": 217140,
+      "meanMicros": 264303.1,
+      "medianMicros": 262489.0,
+      "maxMicros": 330806,
+      "charsPerSecond": 55674.71588490639
+    },
+    {
+      "case": "test/db",
+      "path": "luascripts/test/db.lua",
+      "source": {
+        "characters": 26597,
+        "lines": 1066,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        371215,
+        345437,
+        330713,
+        397206,
+        311547,
+        397175,
+        485472,
+        441112,
+        393042,
+        400746
+      ],
+      "minMicros": 311547,
+      "meanMicros": 387366.5,
+      "medianMicros": 395108.5,
+      "maxMicros": 485472,
+      "charsPerSecond": 68661.0742023381
+    },
+    {
+      "case": "test/files",
+      "path": "luascripts/test/files.lua",
+      "source": {
+        "characters": 28151,
+        "lines": 1011,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        431574,
+        302112,
+        301289,
+        322907,
+        322852,
+        308377,
+        323274,
+        344075,
+        429399,
+        450800
+      ],
+      "minMicros": 301289,
+      "meanMicros": 353665.9,
+      "medianMicros": 323090.5,
+      "maxMicros": 450800,
+      "charsPerSecond": 79597.72203087715
+    },
+    {
+      "case": "test/locals",
+      "path": "luascripts/test/locals.lua",
+      "source": {
+        "characters": 30652,
+        "lines": 1228,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        256460,
+        184468,
+        160540,
+        158889,
+        151152,
+        169746,
+        161083,
+        147508,
+        160530,
+        178994
+      ],
+      "minMicros": 147508,
+      "meanMicros": 172937.0,
+      "medianMicros": 160811.5,
+      "maxMicros": 256460,
+      "charsPerSecond": 177243.73615825415
+    },
+    {
+      "case": "test/math",
+      "path": "luascripts/test/math.lua",
+      "source": {
+        "characters": 33144,
+        "lines": 1146,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        312458,
+        325791,
+        272683,
+        248183,
+        348719,
+        269469,
+        282974,
+        235417,
+        220176,
+        260056
+      ],
+      "minMicros": 220176,
+      "meanMicros": 277592.6,
+      "medianMicros": 271076.0,
+      "maxMicros": 348719,
+      "charsPerSecond": 119397.9954797066
+    },
+    {
+      "case": "test/pm",
+      "path": "luascripts/test/pm.lua",
+      "source": {
+        "characters": 13818,
+        "lines": 443,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        298771,
+        296505,
+        289253,
+        285236,
+        281572,
+        303059,
+        294982,
+        298387,
+        297887,
+        290630
+      ],
+      "minMicros": 281572,
+      "meanMicros": 293628.2,
+      "medianMicros": 295743.5,
+      "maxMicros": 303059,
+      "charsPerSecond": 47059.51267623477
+    },
+    {
+      "case": "test/strings",
+      "path": "luascripts/test/strings.lua",
+      "source": {
+        "characters": 19405,
+        "lines": 564,
+        "encoding": "latin1"
+      },
+      "samplesMicros": [
+        346961,
+        368250,
+        510524,
+        458651,
+        382990,
+        350957,
+        365624,
+        363215,
+        344259,
+        359509
+      ],
+      "minMicros": 344259,
+      "meanMicros": 385094.0,
+      "medianMicros": 364419.5,
+      "maxMicros": 510524,
+      "charsPerSecond": 50390.294317750995
+    }
+  ],
+  "total": {
+    "meanMicros": 3082080.4000000004,
+    "meanMs": 3082.0804000000003
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-baseline-small.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-baseline-small.json
@@ -1,0 +1,200 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T11:01:07.487256",
+  "label": "origin/ir small-parser-corpus",
+  "packageRoot": "/tmp/lualike-parser-baseline.KGLNIO/pkgs/lualike",
+  "git": {
+    "revision": "3f9069998692cf93cbc5461fe1d3e4150425a7ff",
+    "branch": null,
+    "dirty": true,
+    "statusShort": [
+      "M ../../pubspec.lock",
+      "?? luascripts/parser_profiles/",
+      "?? tool/parser_profile.dart",
+      "?? tool/parser_profile_compare.dart"
+    ]
+  },
+  "corpus": {
+    "directory": "/tmp/lualike-parser-baseline.KGLNIO/pkgs/lualike/luascripts/parser_profiles",
+    "relativeDirectory": "luascripts/parser_profiles"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=origin/ir small-parser-corpus",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-baseline-small.json",
+    "--no-fail-fast"
+  ],
+  "rows": [
+    {
+      "case": "attributes_and_labels",
+      "path": "luascripts/parser_profiles/attributes_and_labels.lua",
+      "source": {
+        "characters": 122,
+        "lines": 11,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        2886,
+        2421,
+        2838,
+        3841,
+        2134,
+        2590,
+        2074,
+        2155,
+        1727,
+        1467
+      ],
+      "minMicros": 1467,
+      "meanMicros": 2413.3,
+      "medianMicros": 2288.0,
+      "maxMicros": 3841,
+      "charsPerSecond": 50553.18443624912
+    },
+    {
+      "case": "branches_and_loops",
+      "path": "luascripts/parser_profiles/branches_and_loops.lua",
+      "source": {
+        "characters": 263,
+        "lines": 22,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        1697,
+        1566,
+        1659,
+        1722,
+        1464,
+        1539,
+        1624,
+        1637,
+        2616,
+        2360
+      ],
+      "minMicros": 1464,
+      "meanMicros": 1788.4,
+      "medianMicros": 1648.0,
+      "maxMicros": 2616,
+      "charsPerSecond": 147058.82352941175
+    },
+    {
+      "case": "functions_and_calls",
+      "path": "luascripts/parser_profiles/functions_and_calls.lua",
+      "source": {
+        "characters": 261,
+        "lines": 15,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        3158,
+        1815,
+        1633,
+        1678,
+        1776,
+        1524,
+        1655,
+        1935,
+        1621,
+        1408
+      ],
+      "minMicros": 1408,
+      "meanMicros": 1820.3,
+      "medianMicros": 1666.5,
+      "maxMicros": 3158,
+      "charsPerSecond": 143382.95885293634
+    },
+    {
+      "case": "literals_and_expressions",
+      "path": "luascripts/parser_profiles/literals_and_expressions.lua",
+      "source": {
+        "characters": 152,
+        "lines": 6,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        740,
+        755,
+        1162,
+        816,
+        1118,
+        988,
+        1010,
+        1059,
+        904,
+        658
+      ],
+      "minMicros": 658,
+      "meanMicros": 921.0,
+      "medianMicros": 946.0,
+      "maxMicros": 1162,
+      "charsPerSecond": 165038.00217155265
+    },
+    {
+      "case": "strings_and_comments",
+      "path": "luascripts/parser_profiles/strings_and_comments.lua",
+      "source": {
+        "characters": 254,
+        "lines": 13,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        4160,
+        4480,
+        3772,
+        3134,
+        2313,
+        2361,
+        2577,
+        1815,
+        1811,
+        2050
+      ],
+      "minMicros": 1811,
+      "meanMicros": 2847.3,
+      "medianMicros": 2469.0,
+      "maxMicros": 4480,
+      "charsPerSecond": 89207.31921469462
+    },
+    {
+      "case": "table_shapes",
+      "path": "luascripts/parser_profiles/table_shapes.lua",
+      "source": {
+        "characters": 233,
+        "lines": 12,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        4705,
+        4383,
+        2866,
+        3561,
+        2910,
+        2576,
+        2778,
+        4300,
+        2685,
+        2573
+      ],
+      "minMicros": 2573,
+      "meanMicros": 3333.7,
+      "medianMicros": 2888.0,
+      "maxMicros": 4705,
+      "charsPerSecond": 69892.31184569698
+    }
+  ],
+  "total": {
+    "meanMicros": 13124.0,
+    "meanMs": 13.124
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-comparison-hot.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-comparison-hot.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile_compare.dart",
+  "title": "Hot Lua Suite",
+  "generatedAt": "2026-05-03T11:02:08.680458",
+  "baseline": {
+    "label": "origin/ir hot-lua-suite",
+    "capturedAt": "2026-05-03T11:02:02.979423",
+    "revision": "3f9069998692cf93cbc5461fe1d3e4150425a7ff",
+    "branch": null
+  },
+  "latest": {
+    "label": "current hot-lua-suite",
+    "capturedAt": "2026-05-03T11:02:08.015675",
+    "revision": "a6d79f1e2b1318309ea8b1890c67f81afe2acb8d",
+    "branch": "profiling/parser-performance"
+  },
+  "rows": [
+    {
+      "case": "strings",
+      "baselineMeanMicros": 656439.6,
+      "latestMeanMicros": 10998.8,
+      "timeReductionPercent": 98.32447646363808,
+      "speedup": 59.68283812779576
+    },
+    {
+      "case": "test/api",
+      "baselineMeanMicros": 291053.5,
+      "latestMeanMicros": 11676.9,
+      "timeReductionPercent": 95.98805717849123,
+      "speedup": 24.925579563068965
+    },
+    {
+      "case": "test/code",
+      "baselineMeanMicros": 264303.1,
+      "latestMeanMicros": 5468.1,
+      "timeReductionPercent": 97.93112528759595,
+      "speedup": 48.33545472833342
+    },
+    {
+      "case": "test/db",
+      "baselineMeanMicros": 387366.5,
+      "latestMeanMicros": 7091.1,
+      "timeReductionPercent": 98.16940804122194,
+      "speedup": 54.62713824371395
+    },
+    {
+      "case": "test/files",
+      "baselineMeanMicros": 353665.9,
+      "latestMeanMicros": 7561.7,
+      "timeReductionPercent": 97.86190865446738,
+      "speedup": 46.770686485843136
+    },
+    {
+      "case": "test/locals",
+      "baselineMeanMicros": 172937.0,
+      "latestMeanMicros": 5900.6,
+      "timeReductionPercent": 96.58800603688049,
+      "speedup": 29.30837541944887
+    },
+    {
+      "case": "test/math",
+      "baselineMeanMicros": 277592.6,
+      "latestMeanMicros": 9601.5,
+      "timeReductionPercent": 96.54115419503258,
+      "speedup": 28.911378430453574
+    },
+    {
+      "case": "test/pm",
+      "baselineMeanMicros": 293628.2,
+      "latestMeanMicros": 3708.2,
+      "timeReductionPercent": 98.73711040015911,
+      "speedup": 79.18348524890783
+    },
+    {
+      "case": "test/strings",
+      "baselineMeanMicros": 385094.0,
+      "latestMeanMicros": 5788.3,
+      "timeReductionPercent": 98.49691244215698,
+      "speedup": 66.52972375308812
+    }
+  ],
+  "total": {
+    "baselineMeanMicros": 3082080.4000000004,
+    "latestMeanMicros": 67795.19999999998,
+    "timeReductionPercent": 97.80034291123617,
+    "speedup": 45.46163150193526
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-comparison-hot.md
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-comparison-hot.md
@@ -1,0 +1,26 @@
+# Hot Lua Suite
+
+Generated: `2026-05-03T11:02:08.680458`
+
+Baseline: `origin/ir hot-lua-suite`, revision `3f9069998692`, captured `2026-05-03T11:02:02.979423`
+
+Latest: `current hot-lua-suite`, revision `a6d79f1e2b13`, branch `profiling/parser-performance`, captured `2026-05-03T11:02:08.015675`
+
+Percentage improvement is mean parse-time reduction:
+
+```text
+(baseline mean - latest mean) / baseline mean
+```
+
+| Case | Baseline | Latest | Reduction | Speedup |
+| --- | ---: | ---: | ---: | ---: |
+| `strings` | `656.440 ms` | `10.999 ms` | `98.3%` | `59.7x` |
+| `test/api` | `291.053 ms` | `11.677 ms` | `96.0%` | `24.9x` |
+| `test/code` | `264.303 ms` | `5.468 ms` | `97.9%` | `48.3x` |
+| `test/db` | `387.366 ms` | `7.091 ms` | `98.2%` | `54.6x` |
+| `test/files` | `353.666 ms` | `7.562 ms` | `97.9%` | `46.8x` |
+| `test/locals` | `172.937 ms` | `5.901 ms` | `96.6%` | `29.3x` |
+| `test/math` | `277.593 ms` | `9.601 ms` | `96.5%` | `28.9x` |
+| `test/pm` | `293.628 ms` | `3.708 ms` | `98.7%` | `79.2x` |
+| `test/strings` | `385.094 ms` | `5.788 ms` | `98.5%` | `66.5x` |
+| **Total** | `3082.080 ms` | `67.795 ms` | **`97.8%`** | **`45.5x`** |

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-comparison-small.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-comparison-small.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile_compare.dart",
+  "title": "Small Parser Corpus",
+  "generatedAt": "2026-05-03T11:01:12.710519",
+  "baseline": {
+    "label": "origin/ir small-parser-corpus",
+    "capturedAt": "2026-05-03T11:01:07.487256",
+    "revision": "3f9069998692cf93cbc5461fe1d3e4150425a7ff",
+    "branch": null
+  },
+  "latest": {
+    "label": "current small-parser-corpus",
+    "capturedAt": "2026-05-03T11:01:11.924994",
+    "revision": "a6d79f1e2b1318309ea8b1890c67f81afe2acb8d",
+    "branch": "profiling/parser-performance"
+  },
+  "rows": [
+    {
+      "case": "attributes_and_labels",
+      "baselineMeanMicros": 2413.3,
+      "latestMeanMicros": 772.5,
+      "timeReductionPercent": 67.98988936311275,
+      "speedup": 3.124012944983819
+    },
+    {
+      "case": "branches_and_loops",
+      "baselineMeanMicros": 1788.4,
+      "latestMeanMicros": 1218.9,
+      "timeReductionPercent": 31.844106463878326,
+      "speedup": 1.4672245467224547
+    },
+    {
+      "case": "functions_and_calls",
+      "baselineMeanMicros": 1820.3,
+      "latestMeanMicros": 692.4,
+      "timeReductionPercent": 61.962313904301496,
+      "speedup": 2.6289716926632005
+    },
+    {
+      "case": "literals_and_expressions",
+      "baselineMeanMicros": 921.0,
+      "latestMeanMicros": 516.6,
+      "timeReductionPercent": 43.90879478827362,
+      "speedup": 1.7828106852497096
+    },
+    {
+      "case": "strings_and_comments",
+      "baselineMeanMicros": 2847.3,
+      "latestMeanMicros": 386.0,
+      "timeReductionPercent": 86.44329715871177,
+      "speedup": 7.376424870466321
+    },
+    {
+      "case": "table_shapes",
+      "baselineMeanMicros": 3333.7,
+      "latestMeanMicros": 574.4,
+      "timeReductionPercent": 82.76989531151574,
+      "speedup": 5.803795264623956
+    }
+  ],
+  "total": {
+    "baselineMeanMicros": 13124.0,
+    "latestMeanMicros": 4160.8,
+    "timeReductionPercent": 68.29625114294423,
+    "speedup": 3.1542011151701597
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-comparison-small.md
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-comparison-small.md
@@ -1,0 +1,23 @@
+# Small Parser Corpus
+
+Generated: `2026-05-03T11:01:12.710519`
+
+Baseline: `origin/ir small-parser-corpus`, revision `3f9069998692`, captured `2026-05-03T11:01:07.487256`
+
+Latest: `current small-parser-corpus`, revision `a6d79f1e2b13`, branch `profiling/parser-performance`, captured `2026-05-03T11:01:11.924994`
+
+Percentage improvement is mean parse-time reduction:
+
+```text
+(baseline mean - latest mean) / baseline mean
+```
+
+| Case | Baseline | Latest | Reduction | Speedup |
+| --- | ---: | ---: | ---: | ---: |
+| `attributes_and_labels` | `2.413 ms` | `0.772 ms` | `68.0%` | `3.1x` |
+| `branches_and_loops` | `1.788 ms` | `1.219 ms` | `31.8%` | `1.5x` |
+| `functions_and_calls` | `1.820 ms` | `0.692 ms` | `62.0%` | `2.6x` |
+| `literals_and_expressions` | `0.921 ms` | `0.517 ms` | `43.9%` | `1.8x` |
+| `strings_and_comments` | `2.847 ms` | `0.386 ms` | `86.4%` | `7.4x` |
+| `table_shapes` | `3.334 ms` | `0.574 ms` | `82.8%` | `5.8x` |
+| **Total** | `13.124 ms` | `4.161 ms` | **`68.3%`** | **`3.2x`** |

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-latest-hot.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-latest-hot.json
@@ -1,0 +1,298 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T11:02:08.015675",
+  "label": "current hot-lua-suite",
+  "packageRoot": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike",
+  "git": {
+    "revision": "a6d79f1e2b1318309ea8b1890c67f81afe2acb8d",
+    "branch": "profiling/parser-performance",
+    "dirty": true,
+    "statusShort": [
+      "?? benchmarks/parser_profiles/2026-05-03T11-01-01-baseline-hot.json",
+      "?? benchmarks/parser_profiles/2026-05-03T11-01-01-baseline-small.json",
+      "?? benchmarks/parser_profiles/2026-05-03T11-01-01-comparison-small.json",
+      "?? benchmarks/parser_profiles/2026-05-03T11-01-01-comparison-small.md",
+      "?? benchmarks/parser_profiles/2026-05-03T11-01-01-latest-small.json"
+    ]
+  },
+  "corpus": {
+    "directory": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/luascripts",
+    "relativeDirectory": "luascripts"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=current hot-lua-suite",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-latest-hot.json",
+    "--no-fail-fast",
+    "-c",
+    "strings",
+    "-c",
+    "test/api",
+    "-c",
+    "test/files",
+    "-c",
+    "test/math",
+    "-c",
+    "test/db",
+    "-c",
+    "test/locals",
+    "-c",
+    "test/code",
+    "-c",
+    "test/pm",
+    "-c",
+    "test/strings",
+    "--corpus=luascripts"
+  ],
+  "rows": [
+    {
+      "case": "strings",
+      "path": "luascripts/strings.lua",
+      "source": {
+        "characters": 18253,
+        "lines": 518,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        13899,
+        12832,
+        14277,
+        11208,
+        13205,
+        9903,
+        8279,
+        8099,
+        9008,
+        9278
+      ],
+      "minMicros": 8099,
+      "meanMicros": 10998.8,
+      "medianMicros": 10555.5,
+      "maxMicros": 14277,
+      "charsPerSecond": 1659544.6776011928
+    },
+    {
+      "case": "test/api",
+      "path": "luascripts/test/api.lua",
+      "source": {
+        "characters": 40029,
+        "lines": 1417,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        12221,
+        14043,
+        12417,
+        11550,
+        11242,
+        11350,
+        11787,
+        10475,
+        11004,
+        10680
+      ],
+      "minMicros": 10475,
+      "meanMicros": 11676.9,
+      "medianMicros": 11450.0,
+      "maxMicros": 14043,
+      "charsPerSecond": 3428050.253063741
+    },
+    {
+      "case": "test/code",
+      "path": "luascripts/test/code.lua",
+      "source": {
+        "characters": 14715,
+        "lines": 505,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        6309,
+        5307,
+        5279,
+        6340,
+        5319,
+        5870,
+        4808,
+        4765,
+        5354,
+        5330
+      ],
+      "minMicros": 4765,
+      "meanMicros": 5468.1,
+      "medianMicros": 5324.5,
+      "maxMicros": 6340,
+      "charsPerSecond": 2691062.7091677184
+    },
+    {
+      "case": "test/db",
+      "path": "luascripts/test/db.lua",
+      "source": {
+        "characters": 26597,
+        "lines": 1066,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        7614,
+        8981,
+        6955,
+        7663,
+        6557,
+        6014,
+        6200,
+        7919,
+        7329,
+        5679
+      ],
+      "minMicros": 5679,
+      "meanMicros": 7091.1,
+      "medianMicros": 7142.0,
+      "maxMicros": 8981,
+      "charsPerSecond": 3750757.9924130244
+    },
+    {
+      "case": "test/files",
+      "path": "luascripts/test/files.lua",
+      "source": {
+        "characters": 28151,
+        "lines": 1011,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        7614,
+        8553,
+        7518,
+        8430,
+        6341,
+        7227,
+        7924,
+        6990,
+        8795,
+        6225
+      ],
+      "minMicros": 6225,
+      "meanMicros": 7561.7,
+      "medianMicros": 7566.0,
+      "maxMicros": 8795,
+      "charsPerSecond": 3722840.1020934447
+    },
+    {
+      "case": "test/locals",
+      "path": "luascripts/test/locals.lua",
+      "source": {
+        "characters": 30652,
+        "lines": 1228,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        5883,
+        5311,
+        6022,
+        4885,
+        6668,
+        6131,
+        7553,
+        5493,
+        5813,
+        5247
+      ],
+      "minMicros": 4885,
+      "meanMicros": 5900.6,
+      "medianMicros": 5848.0,
+      "maxMicros": 7553,
+      "charsPerSecond": 5194725.960071856
+    },
+    {
+      "case": "test/math",
+      "path": "luascripts/test/math.lua",
+      "source": {
+        "characters": 33144,
+        "lines": 1146,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        7792,
+        8431,
+        9158,
+        11614,
+        9829,
+        9474,
+        10450,
+        8784,
+        7623,
+        12860
+      ],
+      "minMicros": 7623,
+      "meanMicros": 9601.5,
+      "medianMicros": 9316.0,
+      "maxMicros": 12860,
+      "charsPerSecond": 3451960.6311513823
+    },
+    {
+      "case": "test/pm",
+      "path": "luascripts/test/pm.lua",
+      "source": {
+        "characters": 13818,
+        "lines": 443,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        3105,
+        3385,
+        3532,
+        3380,
+        3730,
+        4314,
+        3714,
+        5485,
+        3201,
+        3236
+      ],
+      "minMicros": 3105,
+      "meanMicros": 3708.2,
+      "medianMicros": 3458.5,
+      "maxMicros": 5485,
+      "charsPerSecond": 3726336.2278194274
+    },
+    {
+      "case": "test/strings",
+      "path": "luascripts/test/strings.lua",
+      "source": {
+        "characters": 19405,
+        "lines": 564,
+        "encoding": "latin1"
+      },
+      "samplesMicros": [
+        4874,
+        4875,
+        5011,
+        6347,
+        5975,
+        5780,
+        5101,
+        5158,
+        6505,
+        8257
+      ],
+      "minMicros": 4874,
+      "meanMicros": 5788.3,
+      "medianMicros": 5469.0,
+      "maxMicros": 8257,
+      "charsPerSecond": 3352452.3607967794
+    }
+  ],
+  "total": {
+    "meanMicros": 67795.19999999998,
+    "meanMs": 67.79519999999998
+  }
+}

--- a/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-latest-small.json
+++ b/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-latest-small.json
@@ -1,0 +1,197 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "tool/parser_profile.dart",
+  "capturedAt": "2026-05-03T11:01:11.924994",
+  "label": "current small-parser-corpus",
+  "packageRoot": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike",
+  "git": {
+    "revision": "a6d79f1e2b1318309ea8b1890c67f81afe2acb8d",
+    "branch": "profiling/parser-performance",
+    "dirty": true,
+    "statusShort": [
+      "?? benchmarks/parser_profiles/2026-05-03T11-01-01-baseline-small.json"
+    ]
+  },
+  "corpus": {
+    "directory": "/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/luascripts/parser_profiles",
+    "relativeDirectory": "luascripts/parser_profiles"
+  },
+  "config": {
+    "warmup": 5,
+    "repeat": 10,
+    "profile": false,
+    "trace": false,
+    "progress": false,
+    "lint": false,
+    "failFast": false
+  },
+  "arguments": [
+    "--warmup=5",
+    "--repeat=10",
+    "--label=current small-parser-corpus",
+    "--json-out=/run/media/kingwill101/disk2/code/code/dart_packages/lualike.worktrees/parser-profiling/pkgs/lualike/benchmarks/parser_profiles/2026-05-03T11-01-01-latest-small.json",
+    "--no-fail-fast"
+  ],
+  "rows": [
+    {
+      "case": "attributes_and_labels",
+      "path": "luascripts/parser_profiles/attributes_and_labels.lua",
+      "source": {
+        "characters": 122,
+        "lines": 11,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        1309,
+        928,
+        679,
+        678,
+        682,
+        672,
+        719,
+        662,
+        706,
+        690
+      ],
+      "minMicros": 662,
+      "meanMicros": 772.5,
+      "medianMicros": 686.0,
+      "maxMicros": 1309,
+      "charsPerSecond": 157928.80258899677
+    },
+    {
+      "case": "branches_and_loops",
+      "path": "luascripts/parser_profiles/branches_and_loops.lua",
+      "source": {
+        "characters": 263,
+        "lines": 22,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        1199,
+        1190,
+        1097,
+        1105,
+        1218,
+        1559,
+        1085,
+        1245,
+        907,
+        1584
+      ],
+      "minMicros": 907,
+      "meanMicros": 1218.9,
+      "medianMicros": 1194.5,
+      "maxMicros": 1584,
+      "charsPerSecond": 215768.3156944786
+    },
+    {
+      "case": "functions_and_calls",
+      "path": "luascripts/parser_profiles/functions_and_calls.lua",
+      "source": {
+        "characters": 261,
+        "lines": 15,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        744,
+        544,
+        598,
+        601,
+        519,
+        599,
+        1016,
+        629,
+        1050,
+        624
+      ],
+      "minMicros": 519,
+      "meanMicros": 692.4,
+      "medianMicros": 612.5,
+      "maxMicros": 1050,
+      "charsPerSecond": 376949.740034662
+    },
+    {
+      "case": "literals_and_expressions",
+      "path": "luascripts/parser_profiles/literals_and_expressions.lua",
+      "source": {
+        "characters": 152,
+        "lines": 6,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        476,
+        425,
+        568,
+        448,
+        587,
+        490,
+        490,
+        451,
+        494,
+        737
+      ],
+      "minMicros": 425,
+      "meanMicros": 516.6,
+      "medianMicros": 490.0,
+      "maxMicros": 737,
+      "charsPerSecond": 294231.5137437089
+    },
+    {
+      "case": "strings_and_comments",
+      "path": "luascripts/parser_profiles/strings_and_comments.lua",
+      "source": {
+        "characters": 254,
+        "lines": 13,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        377,
+        311,
+        246,
+        313,
+        444,
+        274,
+        310,
+        918,
+        390,
+        277
+      ],
+      "minMicros": 246,
+      "meanMicros": 386.0,
+      "medianMicros": 312.0,
+      "maxMicros": 918,
+      "charsPerSecond": 658031.0880829016
+    },
+    {
+      "case": "table_shapes",
+      "path": "luascripts/parser_profiles/table_shapes.lua",
+      "source": {
+        "characters": 233,
+        "lines": 12,
+        "encoding": "utf8"
+      },
+      "samplesMicros": [
+        733,
+        654,
+        568,
+        693,
+        576,
+        492,
+        488,
+        480,
+        489,
+        571
+      ],
+      "minMicros": 480,
+      "meanMicros": 574.4,
+      "medianMicros": 569.5,
+      "maxMicros": 733,
+      "charsPerSecond": 405640.6685236769
+    }
+  ],
+  "total": {
+    "meanMicros": 4160.8,
+    "meanMs": 4.1608
+  }
+}

--- a/pkgs/lualike/lib/src/ast.dart
+++ b/pkgs/lualike/lib/src/ast.dart
@@ -1676,6 +1676,14 @@ class StringLiteral extends AstNode implements Dumpable {
     }
   }
 
+  StringLiteral.withParsedBytes(
+    String raw,
+    List<int> bytes, {
+    this.isLongString = false,
+  }) : value = raw {
+    _bytes = bytes;
+  }
+
   /// Get the byte representation of this string literal
   List<int> get bytes => _bytes;
 

--- a/pkgs/lualike/lib/src/parsers/binary_format.dart
+++ b/pkgs/lualike/lib/src/parsers/binary_format.dart
@@ -21,6 +21,11 @@ class BinaryFormatOption {
 /// Parser that turns a Lua 5.4 binary-format string into a list of
 /// [BinaryFormatOption]s, performing the same validation that the Lua VM does.
 class BinaryFormatParser {
+  static final String _maxIntegerDigits = NumberLimits.maxInteger.toString();
+  static final String _minIntegerMagnitudeDigits = NumberLimits.minInteger
+      .toString()
+      .substring(1);
+
   static final Parser<String> space = char(' ');
   static final Parser<String> digits = digit().plus().flatten();
   static final Parser<String> signedDigits = (char('-').optional() & digits)
@@ -208,14 +213,14 @@ class BinaryFormatParser {
       return digitStart;
     }
 
-    final digits = input.substring(digitStart, digitEnd);
-    final n = int.parse(digits);
+    final n = _parseSmallPositiveSize(input, digitStart, digitEnd);
     if (n < 1 || n > 16) {
       throw LuaError("integral size ($n) out of limits [1,16]");
     }
     if ((n & (n - 1)) != 0) {
       throw LuaError("format asks for alignment not power of 2");
     }
+    final digits = input.substring(digitStart, digitEnd);
     raw.add(BinaryFormatOption('!', align: n, raw: '!$digits'));
     return digitEnd;
   }
@@ -231,12 +236,9 @@ class BinaryFormatParser {
       throw LuaError('missing size');
     }
 
+    final n = _parseBoundedUnsignedInteger(input, digitStart, digitEnd);
     final digits = input.substring(digitStart, digitEnd);
-    final bigN = BigInt.parse(digits);
-    if (bigN > BigInt.from(NumberLimits.maxInteger)) {
-      throw LuaError('invalid format');
-    }
-    raw.add(BinaryFormatOption('c', size: bigN.toInt(), raw: 'c$digits'));
+    raw.add(BinaryFormatOption('c', size: n, raw: 'c$digits'));
     return digitEnd;
   }
 
@@ -254,14 +256,7 @@ class BinaryFormatParser {
 
     final digitEnd = _scanDigits(input, digitStart);
     final numberStart = position + 1;
-    final numberText = input.substring(numberStart, digitEnd);
-    final bigN = BigInt.parse(numberText);
-    if (bigN > BigInt.from(NumberLimits.maxInteger) ||
-        bigN < BigInt.from(NumberLimits.minInteger)) {
-      throw LuaError('invalid format');
-    }
-
-    final n = bigN.toInt();
+    final n = _parseBoundedSignedInteger(input, numberStart, digitEnd);
     if ((type == 'i' || type == 'I' || type == 'j' || type == 'J') &&
         (n < 1 || n > 16)) {
       throw LuaError("integral size ($n) out of limits [1,16]");
@@ -270,8 +265,64 @@ class BinaryFormatParser {
       throw LuaError("invalid size for format option 's'");
     }
 
+    final numberText = input.substring(numberStart, digitEnd);
     raw.add(BinaryFormatOption(type, size: n, raw: '$type$numberText'));
     return digitEnd;
+  }
+
+  static int _parseSmallPositiveSize(String input, int start, int end) {
+    final significantStart = _skipLeadingZeroDigits(input, start, end);
+    if (end - significantStart > 2) {
+      return 17;
+    }
+    return int.parse(input.substring(start, end));
+  }
+
+  static int _parseBoundedUnsignedInteger(String input, int start, int end) {
+    if (_digitsExceed(input, start, end, _maxIntegerDigits)) {
+      throw LuaError('invalid format');
+    }
+    return int.parse(input.substring(start, end));
+  }
+
+  static int _parseBoundedSignedInteger(String input, int start, int end) {
+    final isNegative = input.codeUnitAt(start) == 0x2D;
+    final digitStart = isNegative ? start + 1 : start;
+    final limit = isNegative ? _minIntegerMagnitudeDigits : _maxIntegerDigits;
+    if (_digitsExceed(input, digitStart, end, limit)) {
+      throw LuaError('invalid format');
+    }
+    return int.parse(input.substring(start, end));
+  }
+
+  static bool _digitsExceed(
+    String input,
+    int start,
+    int end,
+    String limitDigits,
+  ) {
+    final significantStart = _skipLeadingZeroDigits(input, start, end);
+    final length = end - significantStart;
+    if (length != limitDigits.length) {
+      return length > limitDigits.length;
+    }
+
+    for (var i = 0; i < length; i++) {
+      final digit = input.codeUnitAt(significantStart + i);
+      final limit = limitDigits.codeUnitAt(i);
+      if (digit != limit) {
+        return digit > limit;
+      }
+    }
+    return false;
+  }
+
+  static int _skipLeadingZeroDigits(String input, int start, int end) {
+    var current = start;
+    while (current + 1 < end && input.codeUnitAt(current) == 0x30) {
+      current++;
+    }
+    return current;
   }
 
   static int? _signedDigitsStart(String input, int position) {

--- a/pkgs/lualike/lib/src/parsers/binary_format.dart
+++ b/pkgs/lualike/lib/src/parsers/binary_format.dart
@@ -129,85 +129,228 @@ class BinaryFormatParser {
 
   /// Parse [input] into a list of [BinaryFormatOption]s or throw [LuaError].
   static List<BinaryFormatOption> parse(String input) {
-    for (var i = 0; i < input.length; i++) {
-      if (input[i] == 'X') {
-        if (i + 1 >= input.length || input[i + 1].trim().isEmpty) {
+    final raw = <BinaryFormatOption>[];
+    var current = 0;
+    while (current < input.length) {
+      final codeUnit = input.codeUnitAt(current);
+      if (codeUnit == 0x20) {
+        current++;
+        continue;
+      }
+
+      if (codeUnit == 0x58) {
+        if (current + 1 >= input.length || input[current + 1].trim().isEmpty) {
           throw LuaError("invalid next option for option 'X'");
         }
       }
+
+      switch (codeUnit) {
+        case 0x3C: // <
+        case 0x3D: // =
+        case 0x3E: // >
+          final rawOption = input[current];
+          raw.add(BinaryFormatOption(rawOption, raw: rawOption));
+          current++;
+          break;
+        case 0x21: // !
+          current = _parseAlignment(input, current, raw);
+          break;
+        case 0x63: // c
+          current = _parseCharArray(input, current, raw);
+          break;
+        case 0x69: // i
+        case 0x49: // I
+        case 0x6A: // j
+        case 0x4A: // J
+        case 0x73: // s
+          current = _parseIntegerOrStringSize(input, current, raw);
+          break;
+        default:
+          final option = input[current];
+          if (_isSimpleOption(codeUnit)) {
+            raw.add(BinaryFormatOption(option, raw: option));
+            current++;
+          } else {
+            throw LuaError.typeError("invalid format option '$option'");
+          }
+      }
     }
 
-    final result = formatParser.parse(input);
-    if (result is Success) {
-      final raw = List<BinaryFormatOption>.from(result.value);
-      final processed = <BinaryFormatOption>[];
-      for (var i = 0; i < raw.length; i++) {
-        final opt = raw[i];
-        if (opt.type == 'X') {
-          if (i + 1 >= raw.length) {
-            throw LuaError("invalid next option for option 'X'");
-          }
-          final next = raw[i + 1];
-          int size;
-          switch (next.type) {
-            case 'b':
-              size = BinaryTypeSize.b;
-              break;
-            case 'B':
-              size = BinaryTypeSize.B;
-              break;
-            case 'h':
-              size = BinaryTypeSize.h;
-              break;
-            case 'H':
-              size = BinaryTypeSize.H;
-              break;
-            case 'l':
-              size = BinaryTypeSize.l;
-              break;
-            case 'L':
-              size = BinaryTypeSize.L;
-              break;
-            case 'j':
-              size = BinaryTypeSize.j;
-              break;
-            case 'J':
-              size = BinaryTypeSize.J;
-              break;
-            case 'T':
-              size = BinaryTypeSize.T;
-              break;
-            case 'f':
-              size = BinaryTypeSize.f;
-              break;
-            case 'd':
-              size = BinaryTypeSize.d;
-              break;
-            case 'n':
-              size = BinaryTypeSize.n;
-              break;
-            case 'i':
-              size = next.size ?? BinaryTypeSize.i;
-              break;
-            case 'I':
-              size = next.size ?? BinaryTypeSize.I;
-              break;
-            default:
-              throw LuaError("invalid next option for option 'X'");
-          }
-          processed.add(
-            BinaryFormatOption('X', size: size, raw: opt.raw + next.raw),
-          );
-          i++; // skip next
-        } else {
-          processed.add(opt);
+    final processed = <BinaryFormatOption>[];
+    for (var i = 0; i < raw.length; i++) {
+      final opt = raw[i];
+      if (opt.type == 'X') {
+        if (i + 1 >= raw.length) {
+          throw LuaError("invalid next option for option 'X'");
         }
+        final next = raw[i + 1];
+        final size = _paddingSizeFor(next);
+        processed.add(
+          BinaryFormatOption('X', size: size, raw: opt.raw + next.raw),
+        );
+        i++;
+      } else {
+        processed.add(opt);
       }
-      return processed;
     }
-    // Failure – PetitParser tells us where it got stuck.
-    throw LuaError.typeError(
-      "invalid format option at position ${result.position}",
-    );
+    return processed;
+  }
+
+  static int _parseAlignment(
+    String input,
+    int position,
+    List<BinaryFormatOption> raw,
+  ) {
+    final digitStart = position + 1;
+    final digitEnd = _scanDigits(input, digitStart);
+    if (digitEnd == digitStart) {
+      raw.add(BinaryFormatOption('!', raw: '!'));
+      return digitStart;
+    }
+
+    final digits = input.substring(digitStart, digitEnd);
+    final n = int.parse(digits);
+    if (n < 1 || n > 16) {
+      throw LuaError("integral size ($n) out of limits [1,16]");
+    }
+    if ((n & (n - 1)) != 0) {
+      throw LuaError("format asks for alignment not power of 2");
+    }
+    raw.add(BinaryFormatOption('!', align: n, raw: '!$digits'));
+    return digitEnd;
+  }
+
+  static int _parseCharArray(
+    String input,
+    int position,
+    List<BinaryFormatOption> raw,
+  ) {
+    final digitStart = position + 1;
+    final digitEnd = _scanDigits(input, digitStart);
+    if (digitEnd == digitStart) {
+      throw LuaError('missing size');
+    }
+
+    final digits = input.substring(digitStart, digitEnd);
+    final bigN = BigInt.parse(digits);
+    if (bigN > BigInt.from(NumberLimits.maxInteger)) {
+      throw LuaError('invalid format');
+    }
+    raw.add(BinaryFormatOption('c', size: bigN.toInt(), raw: 'c$digits'));
+    return digitEnd;
+  }
+
+  static int _parseIntegerOrStringSize(
+    String input,
+    int position,
+    List<BinaryFormatOption> raw,
+  ) {
+    final type = input[position];
+    final digitStart = _signedDigitsStart(input, position + 1);
+    if (digitStart == null) {
+      raw.add(BinaryFormatOption(type, raw: type));
+      return position + 1;
+    }
+
+    final digitEnd = _scanDigits(input, digitStart);
+    final numberStart = position + 1;
+    final numberText = input.substring(numberStart, digitEnd);
+    final bigN = BigInt.parse(numberText);
+    if (bigN > BigInt.from(NumberLimits.maxInteger) ||
+        bigN < BigInt.from(NumberLimits.minInteger)) {
+      throw LuaError('invalid format');
+    }
+
+    final n = bigN.toInt();
+    if ((type == 'i' || type == 'I' || type == 'j' || type == 'J') &&
+        (n < 1 || n > 16)) {
+      throw LuaError("integral size ($n) out of limits [1,16]");
+    }
+    if (type == 's' && n < 0) {
+      throw LuaError("invalid size for format option 's'");
+    }
+
+    raw.add(BinaryFormatOption(type, size: n, raw: '$type$numberText'));
+    return digitEnd;
+  }
+
+  static int? _signedDigitsStart(String input, int position) {
+    if (position >= input.length) {
+      return null;
+    }
+    final codeUnit = input.codeUnitAt(position);
+    if (_isDigit(codeUnit)) {
+      return position;
+    }
+    if (codeUnit == 0x2D &&
+        position + 1 < input.length &&
+        _isDigit(input.codeUnitAt(position + 1))) {
+      return position + 1;
+    }
+    return null;
+  }
+
+  static int _scanDigits(String input, int position) {
+    var current = position;
+    while (current < input.length && _isDigit(input.codeUnitAt(current))) {
+      current++;
+    }
+    return current;
+  }
+
+  static bool _isDigit(int codeUnit) => codeUnit >= 0x30 && codeUnit <= 0x39;
+
+  static bool _isSimpleOption(int codeUnit) {
+    switch (codeUnit) {
+      case 0x62: // b
+      case 0x42: // B
+      case 0x68: // h
+      case 0x48: // H
+      case 0x6C: // l
+      case 0x4C: // L
+      case 0x54: // T
+      case 0x64: // d
+      case 0x6E: // n
+      case 0x78: // x
+      case 0x7A: // z
+      case 0x58: // X
+      case 0x66: // f
+        return true;
+    }
+    return false;
+  }
+
+  static int _paddingSizeFor(BinaryFormatOption option) {
+    switch (option.type) {
+      case 'b':
+        return BinaryTypeSize.b;
+      case 'B':
+        return BinaryTypeSize.B;
+      case 'h':
+        return BinaryTypeSize.h;
+      case 'H':
+        return BinaryTypeSize.H;
+      case 'l':
+        return BinaryTypeSize.l;
+      case 'L':
+        return BinaryTypeSize.L;
+      case 'j':
+        return BinaryTypeSize.j;
+      case 'J':
+        return BinaryTypeSize.J;
+      case 'T':
+        return BinaryTypeSize.T;
+      case 'f':
+        return BinaryTypeSize.f;
+      case 'd':
+        return BinaryTypeSize.d;
+      case 'n':
+        return BinaryTypeSize.n;
+      case 'i':
+        return option.size ?? BinaryTypeSize.i;
+      case 'I':
+        return option.size ?? BinaryTypeSize.I;
+    }
+    throw LuaError("invalid next option for option 'X'");
   }
 }

--- a/pkgs/lualike/lib/src/parsers/format.dart
+++ b/pkgs/lualike/lib/src/parsers/format.dart
@@ -91,12 +91,74 @@ class FormatStringParser {
 
   /// Parses a format string into a list of FormatPart (literals and specifiers).
   static List<FormatPart> parse(String input) {
-    final result = formatStringParser.parse(input);
-    if (result is Success) {
-      return List<FormatPart>.from(result.value);
-    } else {
-      throw FormatException('Invalid format string: ${result.message}');
+    final parts = <FormatPart>[];
+    var current = 0;
+    var literalStart = 0;
+
+    while (current < input.length) {
+      if (input.codeUnitAt(current) != 0x25) {
+        current++;
+        continue;
+      }
+
+      if (literalStart < current) {
+        parts.add(LiteralPart(input.substring(literalStart, current)));
+      }
+
+      final specifierStart = current;
+      current++;
+
+      final flagsStart = current;
+      while (current < input.length &&
+          _isFormatFlag(input.codeUnitAt(current))) {
+        current++;
+      }
+      final flags = input.substring(flagsStart, current);
+
+      String? width;
+      final widthStart = current;
+      while (current < input.length && _isDigit(input.codeUnitAt(current))) {
+        current++;
+      }
+      if (current > widthStart) {
+        width = input.substring(widthStart, current);
+      }
+
+      String? precision;
+      if (current < input.length && input.codeUnitAt(current) == 0x2E) {
+        final precisionStart = current;
+        current++;
+        while (current < input.length && _isDigit(input.codeUnitAt(current))) {
+          current++;
+        }
+        precision = input.substring(precisionStart, current);
+      }
+
+      if (current >= input.length ||
+          !_isFormatSpecifier(input.codeUnitAt(current))) {
+        throw const FormatException(
+          'Invalid format string: end of input expected',
+        );
+      }
+
+      final specifier = input[current];
+      current++;
+      parts.add(
+        SpecifierPart(
+          full: input.substring(specifierStart, current),
+          flags: flags,
+          width: width,
+          precision: precision,
+          specifier: specifier,
+        ),
+      );
+      literalStart = current;
     }
+
+    if (literalStart < input.length) {
+      parts.add(LiteralPart(input.substring(literalStart)));
+    }
+    return parts;
   }
 
   /// Parses and caches format strings, which are often reused in tight loops.
@@ -113,6 +175,46 @@ class FormatStringParser {
       _parseCache.remove(_parseCache.keys.first);
     }
     return parsed;
+  }
+
+  static bool _isFormatFlag(int codeUnit) {
+    switch (codeUnit) {
+      case 0x2D: // -
+      case 0x2B: // +
+      case 0x20: // space
+      case 0x30: // 0
+      case 0x23: // #
+        return true;
+    }
+    return false;
+  }
+
+  static bool _isDigit(int codeUnit) => codeUnit >= 0x30 && codeUnit <= 0x39;
+
+  static bool _isFormatSpecifier(int codeUnit) {
+    switch (codeUnit) {
+      case 0x63: // c
+      case 0x64: // d
+      case 0x69: // i
+      case 0x6F: // o
+      case 0x75: // u
+      case 0x78: // x
+      case 0x58: // X
+      case 0x65: // e
+      case 0x45: // E
+      case 0x66: // f
+      case 0x67: // g
+      case 0x47: // G
+      case 0x71: // q
+      case 0x51: // Q
+      case 0x73: // s
+      case 0x25: // %
+      case 0x61: // a
+      case 0x41: // A
+      case 0x70: // p
+        return true;
+    }
+    return false;
   }
 
   /// Escapes a byte list according to Lua's %q format rules.

--- a/pkgs/lualike/lib/src/parsers/ir_reader.dart
+++ b/pkgs/lualike/lib/src/parsers/ir_reader.dart
@@ -11,6 +11,7 @@ typedef _PrototypeUpdate = void Function(_ParsedPrototypeBuilder builder);
 typedef _DebugUpdate = void Function(_ParsedDebugInfoBuilder builder);
 
 final Parser<String> _irTriviaParser = _IrTriviaParser();
+final Parser<int> _irIntLiteralParser = _IrIntLiteralParser();
 
 /// Parses a textual `lualike_ir` description into executable IR objects.
 ///
@@ -356,12 +357,7 @@ class _LualikeIrReaderDefinition extends GrammarDefinition {
   Parser _boolLiteral() =>
       _token('true').map((_) => true) | _token('false').map((_) => false);
 
-  Parser _intLiteral() {
-    return (pattern('+-').optional() & digit().plus())
-        .flatten()
-        .trim(ref0(_whitespaceAndComments))
-        .map(int.parse);
-  }
+  Parser _intLiteral() => _irIntLiteralParser;
 
   Parser _doubleLiteral() {
     final exponent = (pattern('eE') & pattern('+-').optional() & digit().plus())
@@ -414,17 +410,108 @@ class _LualikeIrReaderDefinition extends GrammarDefinition {
       inner = parser;
     } else {
       final lexeme = parser as String;
-      final endsWithIdentifier = RegExp(
-        r'[A-Za-z0-9_]',
-      ).hasMatch(lexeme.substring(lexeme.length - 1));
-      if (endsWithIdentifier) {
-        inner = (string(lexeme) & pattern('A-Za-z0-9_').not()).pick(0);
-      } else {
-        inner = string(lexeme);
-      }
+      return _IrTokenParser(
+        lexeme,
+        needsIdentifierBoundary: _isIrIdentifierCodeUnit(
+          lexeme.codeUnitAt(lexeme.length - 1),
+        ),
+      );
     }
     return inner.trim(ref0(_whitespaceAndComments));
   }
+}
+
+class _IrTokenParser extends Parser<String> {
+  _IrTokenParser(this.lexeme, {required this.needsIdentifierBoundary});
+
+  final String lexeme;
+  final bool needsIdentifierBoundary;
+
+  @override
+  Result<String> parseOn(Context context) {
+    final start = _scanIrTrivia(context.buffer, context.position);
+    if (!context.buffer.startsWith(lexeme, start)) {
+      return context.failure('$lexeme expected', start);
+    }
+
+    final end = start + lexeme.length;
+    if (needsIdentifierBoundary &&
+        end < context.buffer.length &&
+        _isIrIdentifierCodeUnit(context.buffer.codeUnitAt(end))) {
+      return context.failure('$lexeme expected', start);
+    }
+
+    return context.success(lexeme, _scanIrTrivia(context.buffer, end));
+  }
+
+  @override
+  int fastParseOn(String buffer, int position) {
+    final start = _scanIrTrivia(buffer, position);
+    if (!buffer.startsWith(lexeme, start)) {
+      return -1;
+    }
+
+    final end = start + lexeme.length;
+    if (needsIdentifierBoundary &&
+        end < buffer.length &&
+        _isIrIdentifierCodeUnit(buffer.codeUnitAt(end))) {
+      return -1;
+    }
+    return _scanIrTrivia(buffer, end);
+  }
+
+  @override
+  _IrTokenParser copy() =>
+      _IrTokenParser(lexeme, needsIdentifierBoundary: needsIdentifierBoundary);
+}
+
+class _IrIntLiteralParser extends Parser<int> {
+  @override
+  Result<int> parseOn(Context context) {
+    final buffer = context.buffer;
+    final start = _scanIrTrivia(buffer, context.position);
+    var current = start;
+
+    if (current < buffer.length) {
+      final sign = buffer.codeUnitAt(current);
+      if (sign == 0x2B || sign == 0x2D) {
+        current++;
+      }
+    }
+
+    final digitStart = current;
+    while (current < buffer.length && _isIrDigit(buffer.codeUnitAt(current))) {
+      current++;
+    }
+    if (current == digitStart) {
+      return context.failure('integer expected', start);
+    }
+
+    final value = int.parse(buffer.substring(start, current));
+    return context.success(value, _scanIrTrivia(buffer, current));
+  }
+
+  @override
+  int fastParseOn(String buffer, int position) {
+    final start = _scanIrTrivia(buffer, position);
+    var current = start;
+
+    if (current < buffer.length) {
+      final sign = buffer.codeUnitAt(current);
+      if (sign == 0x2B || sign == 0x2D) {
+        current++;
+      }
+    }
+
+    final digitStart = current;
+    while (current < buffer.length && _isIrDigit(buffer.codeUnitAt(current))) {
+      current++;
+    }
+    return current == digitStart ? -1 : _scanIrTrivia(buffer, current);
+  }
+
+  @override
+  _IrIntLiteralParser copy() => _IrIntLiteralParser();
 }
 
 class _IrTriviaParser extends Parser<String> {
@@ -507,6 +594,14 @@ bool _isIrWhitespace(int codeUnit) {
   }
   return false;
 }
+
+bool _isIrDigit(int codeUnit) => codeUnit >= 0x30 && codeUnit <= 0x39;
+
+bool _isIrIdentifierCodeUnit(int codeUnit) =>
+    (codeUnit >= 0x41 && codeUnit <= 0x5A) ||
+    (codeUnit >= 0x61 && codeUnit <= 0x7A) ||
+    (codeUnit >= 0x30 && codeUnit <= 0x39) ||
+    codeUnit == 0x5F;
 
 String _decodeString(String content) {
   final bytes = LuaStringParser.parseStringContent(content);

--- a/pkgs/lualike/lib/src/parsers/ir_reader.dart
+++ b/pkgs/lualike/lib/src/parsers/ir_reader.dart
@@ -10,6 +10,8 @@ import 'string.dart';
 typedef _PrototypeUpdate = void Function(_ParsedPrototypeBuilder builder);
 typedef _DebugUpdate = void Function(_ParsedDebugInfoBuilder builder);
 
+final Parser<String> _irTriviaParser = _IrTriviaParser();
+
 /// Parses a textual `lualike_ir` description into executable IR objects.
 ///
 /// The accepted format is intentionally close to the IR model names so the
@@ -404,14 +406,7 @@ class _LualikeIrReaderDefinition extends GrammarDefinition {
     ).plus().flatten().trim(ref0(_whitespaceAndComments));
   }
 
-  Parser _whitespaceAndComments() => (whitespace().plus() | ref0(_lineComment));
-
-  Parser _lineComment() {
-    final endOfLine = string('\r\n') | string('\n\r') | char('\n') | char('\r');
-    final prefix = string('//') | string('#') | string('--');
-    return (prefix & pattern('\r\n').neg().star() & endOfLine.optional())
-        .flatten();
-  }
+  Parser _whitespaceAndComments() => _irTriviaParser;
 
   Parser _token(Object parser) {
     Parser inner;
@@ -430,6 +425,87 @@ class _LualikeIrReaderDefinition extends GrammarDefinition {
     }
     return inner.trim(ref0(_whitespaceAndComments));
   }
+}
+
+class _IrTriviaParser extends Parser<String> {
+  @override
+  Result<String> parseOn(Context context) {
+    final next = _scanIrTrivia(context.buffer, context.position);
+    if (next == context.position) {
+      return context.failure('whitespace or comment expected');
+    }
+    return context.success('', next);
+  }
+
+  @override
+  int fastParseOn(String buffer, int position) {
+    final next = _scanIrTrivia(buffer, position);
+    return next == position ? -1 : next;
+  }
+
+  @override
+  _IrTriviaParser copy() => _IrTriviaParser();
+}
+
+int _scanIrTrivia(String buffer, int position) {
+  var current = position;
+  while (current < buffer.length) {
+    final codeUnit = buffer.codeUnitAt(current);
+    if (_isIrWhitespace(codeUnit)) {
+      current++;
+      continue;
+    }
+    if (codeUnit == 0x23) {
+      current = _scanIrLineComment(buffer, current + 1);
+      continue;
+    }
+    if (current + 1 < buffer.length) {
+      final next = buffer.codeUnitAt(current + 1);
+      if (codeUnit == 0x2F && next == 0x2F) {
+        current = _scanIrLineComment(buffer, current + 2);
+        continue;
+      }
+      if (codeUnit == 0x2D && next == 0x2D) {
+        current = _scanIrLineComment(buffer, current + 2);
+        continue;
+      }
+    }
+    break;
+  }
+  return current;
+}
+
+int _scanIrLineComment(String buffer, int position) {
+  var current = position;
+  while (current < buffer.length) {
+    final codeUnit = buffer.codeUnitAt(current);
+    if (codeUnit == 0x0A || codeUnit == 0x0D) {
+      current++;
+      if (current < buffer.length) {
+        final next = buffer.codeUnitAt(current);
+        if ((codeUnit == 0x0A && next == 0x0D) ||
+            (codeUnit == 0x0D && next == 0x0A)) {
+          current++;
+        }
+      }
+      break;
+    }
+    current++;
+  }
+  return current;
+}
+
+bool _isIrWhitespace(int codeUnit) {
+  switch (codeUnit) {
+    case 0x20: // space
+    case 0x09: // tab
+    case 0x0A: // LF
+    case 0x0D: // CR
+    case 0x0C: // FF
+    case 0x0B: // VT
+      return true;
+  }
+  return false;
 }
 
 String _decodeString(String content) {

--- a/pkgs/lualike/lib/src/parsers/lua.dart
+++ b/pkgs/lualike/lib/src/parsers/lua.dart
@@ -608,14 +608,11 @@ class LuaGrammarDefinition extends GrammarDefinition {
   );
 
   // args ::= '(' [explist] ')' | tableconstructor | LiteralString
-  Parser _args() {
-    final paren = (_token('(') & ref0(_explist).optional() & _token(')')).map(
-      (vals) => vals[1] as List<AstNode>? ?? <AstNode>[],
-    );
-    return paren |
-        ref0(_tableConstructor).map((tc) => [tc]) |
-        _stringLiteral().map((s) => [s]);
-  }
+  Parser _args() => _ArgsParser(
+    expressionList: ref0(_explist),
+    tableConstructor: ref0(_tableConstructor),
+    stringLiteral: _stringLiteral(),
+  );
 
   // ----------------- Simple Control Statements ---------------------------
 
@@ -1729,6 +1726,110 @@ class _SuffixParser extends Parser<_PrefixSuffix> {
     }
     if (args == source) {
       args = target;
+    }
+  }
+}
+
+class _ArgsParser extends Parser<List<AstNode>> {
+  _ArgsParser({
+    required this.expressionList,
+    required this.tableConstructor,
+    required this.stringLiteral,
+  });
+
+  Parser expressionList;
+  Parser tableConstructor;
+  Parser stringLiteral;
+
+  @override
+  Result<List<AstNode>> parseOn(Context context) {
+    final buffer = context.buffer;
+    final start = _skipLuaTrivia(buffer, context.position);
+    if (start >= buffer.length) {
+      return context.failure('arguments expected', start);
+    }
+
+    switch (buffer.codeUnitAt(start)) {
+      case 0x28: // (
+        return _parseParenthesized(context, buffer, start);
+      case 0x7B: // {
+        return _parseSingle(context, tableConstructor, buffer, start);
+      case 0x22: // "
+      case 0x27: // '
+        return _parseSingle(context, stringLiteral, buffer, start);
+      case 0x5B: // [
+        if (_startsLongBracket(buffer, start)) {
+          return _parseSingle(context, stringLiteral, buffer, start);
+        }
+    }
+
+    return context.failure('arguments expected', start);
+  }
+
+  Result<List<AstNode>> _parseParenthesized(
+    Context context,
+    String buffer,
+    int start,
+  ) {
+    var current = _skipLuaTrivia(buffer, start + 1);
+    if (current < buffer.length && buffer.codeUnitAt(current) == 0x29) {
+      return context.success(<AstNode>[], _skipLuaTrivia(buffer, current + 1));
+    }
+
+    final argsResult = expressionList.parseOn(Context(buffer, current));
+    if (argsResult is Failure) {
+      return argsResult;
+    }
+
+    current = _skipLuaTrivia(buffer, argsResult.position);
+    if (current >= buffer.length || buffer.codeUnitAt(current) != 0x29) {
+      return context.failure('")" expected', current);
+    }
+
+    return context.success(
+      (argsResult.value as List).cast<AstNode>(),
+      _skipLuaTrivia(buffer, current + 1),
+    );
+  }
+
+  Result<List<AstNode>> _parseSingle(
+    Context context,
+    Parser parser,
+    String buffer,
+    int start,
+  ) {
+    final result = parser.parseOn(Context(buffer, start));
+    if (result is Failure) {
+      return result;
+    }
+    return context.success([result.value as AstNode], result.position);
+  }
+
+  @override
+  _ArgsParser copy() => _ArgsParser(
+    expressionList: expressionList,
+    tableConstructor: tableConstructor,
+    stringLiteral: stringLiteral,
+  );
+
+  @override
+  List<Parser> get children => [
+    expressionList,
+    tableConstructor,
+    stringLiteral,
+  ];
+
+  @override
+  void replace(Parser source, Parser target) {
+    super.replace(source, target);
+    if (expressionList == source) {
+      expressionList = target;
+    }
+    if (tableConstructor == source) {
+      tableConstructor = target;
+    }
+    if (stringLiteral == source) {
+      stringLiteral = target;
     }
   }
 }

--- a/pkgs/lualike/lib/src/parsers/lua.dart
+++ b/pkgs/lualike/lib/src/parsers/lua.dart
@@ -1066,51 +1066,7 @@ class LuaGrammarDefinition extends GrammarDefinition {
             );
           });
 
-  Parser _parlist() {
-    final namedVararg = (_token('...') & ref0(_identifier)).map((values) {
-      final name = values[1] as Identifier;
-      return {'params': <Identifier>[], 'vararg': true, 'varargName': name};
-    });
-
-    final varargOnly = _token('...').map(
-      (_) => {'params': <Identifier>[], 'vararg': true, 'varargName': null},
-    );
-
-    final namesWithNamedVararg =
-        (_namelist() & _token(',') & _token('...') & ref0(_identifier)).map((
-          vals,
-        ) {
-          final ids = vals[0] as List<Identifier>;
-          final name = vals[3] as Identifier;
-          return {'params': ids, 'vararg': true, 'varargName': name};
-        });
-
-    // names followed by ',', '...'
-    final namesWithVararg = (_namelist() & _token(',') & _token('...')).map((
-      vals,
-    ) {
-      final ids = vals[0] as List<Identifier>;
-      return {'params': ids, 'vararg': true, 'varargName': null};
-    });
-
-    // names only (no vararg) — but *must not* be immediately followed by
-    // an ellipsis. This prevents accepting the invalid Lua pattern
-    // "function f(a, b ...)" (missing comma before `...`). We add a
-    // negative look-ahead (`not()`) for the ellipsis.
-    final namesOnly = (_namelist() & _token('...').not()).map(
-      (vals) => {
-        'params': (vals[0] as List<Identifier>),
-        'vararg': false,
-        'varargName': null,
-      },
-    );
-
-    return namesWithNamedVararg |
-        namesWithVararg |
-        namedVararg |
-        namesOnly |
-        varargOnly;
-  }
+  Parser _parlist() => _ParameterListParser(_identifier());
 
   // Utility to annotate a literal node with span
   T _annotate<T extends AstNode>(T node, int start, int end) {
@@ -2147,6 +2103,118 @@ class _IdentifierParser extends Parser<Identifier> {
 
   @override
   _IdentifierParser copy() => _IdentifierParser(definition);
+}
+
+class _ParameterListParser extends Parser<Map<String, Object?>> {
+  _ParameterListParser(this.identifier);
+
+  Parser identifier;
+
+  @override
+  Result<Map<String, Object?>> parseOn(Context context) {
+    final buffer = context.buffer;
+    var current = _skipLuaTrivia(buffer, context.position);
+    if (current >= buffer.length) {
+      return context.failure('parameter list expected', current);
+    }
+
+    final params = <Identifier>[];
+    var hasVararg = false;
+    Identifier? varargName;
+
+    if (_matchesLexeme(buffer, current, '...')) {
+      current = _skipLuaTrivia(buffer, current + 3);
+      hasVararg = true;
+      final nameResult = _parseOptionalIdentifier(buffer, current);
+      if (nameResult != null) {
+        varargName = nameResult.value;
+        current = nameResult.position;
+      }
+      return context.success({
+        'params': params,
+        'vararg': hasVararg,
+        'varargName': varargName,
+      }, current);
+    }
+
+    final first = identifier.parseOn(Context(buffer, current));
+    if (first is Failure) {
+      return first;
+    }
+    params.add(first.value as Identifier);
+    current = first.position;
+
+    while (true) {
+      current = _skipLuaTrivia(buffer, current);
+      if (current >= buffer.length || buffer.codeUnitAt(current) != 0x2C) {
+        break;
+      }
+
+      current = _skipLuaTrivia(buffer, current + 1);
+      if (_matchesLexeme(buffer, current, '...')) {
+        current = _skipLuaTrivia(buffer, current + 3);
+        hasVararg = true;
+        final nameResult = _parseOptionalIdentifier(buffer, current);
+        if (nameResult != null) {
+          varargName = nameResult.value;
+          current = nameResult.position;
+        }
+        return context.success({
+          'params': params,
+          'vararg': hasVararg,
+          'varargName': varargName,
+        }, current);
+      }
+
+      final next = identifier.parseOn(Context(buffer, current));
+      if (next is Failure) {
+        return next;
+      }
+      params.add(next.value as Identifier);
+      current = next.position;
+    }
+
+    if (_matchesLexeme(buffer, _skipLuaTrivia(buffer, current), '...')) {
+      return context.failure('"," expected', current);
+    }
+
+    return context.success({
+      'params': params,
+      'vararg': hasVararg,
+      'varargName': varargName,
+    }, current);
+  }
+
+  ({Identifier value, int position})? _parseOptionalIdentifier(
+    String buffer,
+    int position,
+  ) {
+    final start = _skipLuaTrivia(buffer, position);
+    if (start >= buffer.length ||
+        !_isIdentifierStartCodeUnit(buffer.codeUnitAt(start))) {
+      return null;
+    }
+
+    final result = identifier.parseOn(Context(buffer, start));
+    if (result is Failure) {
+      return null;
+    }
+    return (value: result.value as Identifier, position: result.position);
+  }
+
+  @override
+  _ParameterListParser copy() => _ParameterListParser(identifier);
+
+  @override
+  List<Parser> get children => [identifier];
+
+  @override
+  void replace(Parser source, Parser target) {
+    super.replace(source, target);
+    if (identifier == source) {
+      identifier = target;
+    }
+  }
 }
 
 int _skipLuaTrivia(String buffer, int position) {

--- a/pkgs/lualike/lib/src/parsers/lua.dart
+++ b/pkgs/lualike/lib/src/parsers/lua.dart
@@ -1,3 +1,5 @@
+import 'dart:convert' as convert;
+
 import 'package:lualike/src/lua_error.dart' show LuaError;
 import 'package:petitparser/petitparser.dart';
 import 'package:source_span/source_span.dart';
@@ -54,31 +56,17 @@ class LuaGrammarDefinition extends GrammarDefinition {
   /// punctuation tokens ("+", "<=", etc.) unchanged while giving keywords
   /// proper word-boundaries.
   Parser _token(Object parser) {
-    Parser inner;
-
     if (parser is Parser) {
-      inner = parser;
-    } else {
-      final String lexeme = parser as String;
-      // Determine if the lexeme ends with an identifier character.
-      final bool endsWithIdentChar = RegExp(
-        r'[A-Za-z0-9_]',
-      ).hasMatch(lexeme.substring(lexeme.length - 1));
-
-      if (endsWithIdentChar) {
-        // Match the exact lexeme, *then* assert the next char is not another
-        // identifier char (negative look-ahead).  `pick(0)` keeps only the
-        // first parser’s result so that downstream code continues to receive
-        // the plain string, not a List.
-        inner = (string(lexeme) & pattern('A-Za-z0-9_').not()).pick(0);
-      } else {
-        inner = string(lexeme);
-      }
+      return parser.trim(ref0(_whiteSpaceAndComments));
     }
 
-    // Attach the trim *after* the inner parser so that we keep the actual
-    // matched lexeme intact for error reporting.
-    return inner.trim(ref0(_whiteSpaceAndComments));
+    final lexeme = parser as String;
+    return _TokenParser(
+      lexeme,
+      needsIdentifierBoundary: _isIdentifierContinueCodeUnit(
+        lexeme.codeUnitAt(lexeme.length - 1),
+      ),
+    );
   }
 
   // Matches at least one whitespace or comment segment. Used by `_token` for
@@ -87,8 +75,7 @@ class LuaGrammarDefinition extends GrammarDefinition {
   // zero-or-more) would recurse indefinitely and trigger PetitParser’s
   // `PossessiveRepeatingParser` assertion. Therefore we use `plus()` here
   // instead of `star()`.
-  Parser _whiteSpaceAndComments() =>
-      (whitespace() | ref0(_longComment) | ref0(_lineComment)).plus();
+  Parser _whiteSpaceAndComments() => _TriviaParser();
 
   /// Recognize a leading hash-line ('#...\n') used as an initial comment in
   /// file-based chunks (Lua skips the first line if it starts with '#'). This
@@ -103,22 +90,12 @@ class LuaGrammarDefinition extends GrammarDefinition {
   /// Optional ESC (0x1B) marker used by the legacy AST/internal chunk path.
   /// Accepting it here allows loader code to uniformly pass decoded text to
   /// the parser even when a legacy chunk starts with ESC.
-  Parser _escMarker() => (pattern('\u001B')).flatten();
+  Parser _escMarker() => char('\u001B');
 
   /// Optional UTF-8 BOM at the very start of a file. When present, it is
   /// ignored by the grammar so users can load files that begin with a BOM
   /// without needing special handling in callers.
   Parser _bom() => string('\uFEFF');
-
-  Parser _lineComment() {
-    final eol = string('\r\n') | string('\n\r') | char('\n') | char('\r');
-    return (string('--') & pattern('\r\n').neg().star() & eol.optional())
-        .flatten();
-  }
-
-  // Long comment --[=[ ... ]=] with optional = depth
-  Parser _longComment() =>
-      (string('--') & _LongCommentBracketParser()).flatten();
 
   // ---------- Lexical tokens ------------------------------------------------
   // Lua identifiers cannot be reserved keywords. Filter them out so that
@@ -150,6 +127,8 @@ class LuaGrammarDefinition extends GrammarDefinition {
     'while',
   };
 
+  static final RegExp _hexEscapePattern = RegExp(r'\\x([0-9A-Fa-f]{2})');
+
   /// Creates a positioned ParserException with accurate source location
   ParserException _createPositionedException(
     dynamic nodeOrPosition,
@@ -179,25 +158,7 @@ class LuaGrammarDefinition extends GrammarDefinition {
     });
   }
 
-  Parser _identifier() {
-    final base = (_letter() & (_letter() | digit()).star()).flatten();
-    // Capture start and end positions to create SourceSpan
-    return position()
-        .seq(base)
-        .seq(position())
-        .trim(ref0(_whiteSpaceAndComments))
-        .map((vals) {
-          final start = vals[0] as int;
-          final text = vals[1] as String;
-          final end = vals[2] as int;
-          final id = Identifier(text);
-          id.setSpan(_sourceFile.span(start, end));
-          return id;
-        })
-        .where((id) => !_keywords.contains((id).name));
-  }
-
-  Parser _letter() => pattern('A-Za-z_');
+  Parser _identifier() => _IdentifierParser(this);
 
   // Matches Lua numeric literals:
   //   • Decimal:  123   1.5   .5   1e3   1.5e-2
@@ -304,8 +265,8 @@ class LuaGrammarDefinition extends GrammarDefinition {
       ref0(_breakStat) |
       ref0(_labelStat) |
       ref0(_gotoStat) |
-      ref0(_assignment) |
       ref0(_returnlessExprStatement) |
+      ref0(_assignment) |
       // Error case: Detect bare string literals and report appropriate error
       _stringLiteral().map((literal) {
         final errorText =
@@ -361,171 +322,26 @@ class LuaGrammarDefinition extends GrammarDefinition {
   }
 
   // explist ::= exp {',' exp}
-  Parser _explist() =>
-      (ref0(_expression) & (_token(',') & ref0(_expression)).star()).map((
-        values,
-      ) {
-        final first = values[0] as AstNode;
-        final restPairs = values[1] as List;
-        final exprs = [first];
-        for (final pair in restPairs) {
-          exprs.add(pair[1] as AstNode);
-        }
-        return exprs;
-      });
+  Parser _explist() => _ExpressionListParser(ref0(_expression), _token(','));
 
-  // Full expression with operator precedence handled by [ExpressionBuilder].
-  Parser _expression() {
-    final builder = ExpressionBuilder();
-
-    // --- Custom primitives: power & unary handling (Lua-specific) ---
-    builder.primitive(ref0(_unaryExpression));
-
-    // --- multiplicative */%// ---
-    builder.group().left(
-      ref0(_mulOperator),
-      (dynamic a, dynamic op, dynamic b) =>
-          _makeBinaryExpression(a as AstNode, op, b as AstNode),
-    );
-
-    // --- additive + - ---
-    builder.group().left(
-      ref0(_addOperator),
-      (dynamic a, dynamic op, dynamic b) =>
-          _makeBinaryExpression(a as AstNode, op, b as AstNode),
-    );
-
-    // --- concatenation .. (right-assoc) ---
-    builder.group().right(
-      _binaryOperatorToken(_token('..')),
-      (dynamic a, dynamic op, dynamic b) =>
-          _makeBinaryExpression(a as AstNode, op, b as AstNode),
-    );
-
-    // --- bitwise shift << >> ---
-    builder.group().left(
-      ref0(_shiftOperator),
-      (dynamic a, dynamic op, dynamic b) =>
-          _makeBinaryExpression(a as AstNode, op, b as AstNode),
-    );
-
-    // --- bitwise and & ---
-    builder.group().left(
-      _binaryOperatorToken(_token('&')),
-      (dynamic a, dynamic op, dynamic b) =>
-          _makeBinaryExpression(a as AstNode, op, b as AstNode),
-    );
-
-    // --- bitwise xor ~ ---
-    builder.group().left(
-      _binaryOperatorToken(_token('~')),
-      (dynamic a, dynamic op, dynamic b) =>
-          _makeBinaryExpression(a as AstNode, op, b as AstNode),
-    );
-
-    // --- bitwise or | ---
-    builder.group().left(
-      _binaryOperatorToken(_token('|')),
-      (dynamic a, dynamic op, dynamic b) =>
-          _makeBinaryExpression(a as AstNode, op, b as AstNode),
-    );
-
-    // --- comparison < > <= >= == ~= ---
-    builder.group().left(
-      ref0(_comparisonOperator),
-      (dynamic a, dynamic op, dynamic b) =>
-          _makeBinaryExpression(a as AstNode, op, b as AstNode),
-    );
-
-    // --- logical and ---
-    builder.group().left(
-      _binaryOperatorToken(_token('and')),
-      (dynamic a, dynamic op, dynamic b) =>
-          _makeBinaryExpression(a as AstNode, op, b as AstNode),
-    );
-
-    // --- logical or (lowest precedence) ---
-    builder.group().left(
-      _binaryOperatorToken(_token('or')),
-      (dynamic a, dynamic op, dynamic b) =>
-          _makeBinaryExpression(a as AstNode, op, b as AstNode),
-    );
-
-    return builder.build().cast<AstNode>();
-  }
-
-  // ---------- Operators parsers -------------------------------------------
-  Parser _unaryOperator() =>
-      (_token('-') | _token('#') | _token('not') | _token('~'));
-
-  Parser _unaryOperatorToken() {
-    return (position() & ref0(_unaryOperator)).map((vals) {
-      final offset = vals[0] as int;
-      final op = vals[1] as String;
-      final line = _sourceFile.location(offset).line;
-      return (op: op, line: line, offset: offset);
-    });
-  }
-
-  Parser _mulOperator() => _binaryOperatorToken(
-    _token('//') | _token('*') | _token('/') | _token('%'),
-  );
-
-  Parser _addOperator() => _binaryOperatorToken(_token('+') | _token('-'));
-
-  Parser _comparisonOperator() => _binaryOperatorToken(
-    _token('<=') |
-        _token('>=') |
-        _token('<') |
-        _token('>') |
-        _token('==') |
-        _token('~='),
-  );
-
-  Parser _shiftOperator() => _binaryOperatorToken(_token('<<') | _token('>>'));
+  // Full expression with operator precedence handled by [_ExpressionParser].
+  Parser _expression() => _ExpressionParser(this, ref0(_unaryExpression));
 
   // ---------- Primary expressions -----------------------------------------
-  Parser _primaryExpression() =>
-      ref0(_functionLiteral).trim(ref0(_whiteSpaceAndComments)) |
-      ref0(_prefixExp).trim(ref0(_whiteSpaceAndComments)) |
-      ref0(_numberLiteral).trim(ref0(_whiteSpaceAndComments)) |
-      ref0(_booleanLiteral).trim(ref0(_whiteSpaceAndComments)) |
-      ref0(_nilLiteral).trim(ref0(_whiteSpaceAndComments)) |
-      ref0(_vararg).trim(ref0(_whiteSpaceAndComments)) |
-      ref0(_stringLiteral).trim(ref0(_whiteSpaceAndComments)) |
-      ref0(_tableConstructor).trim(ref0(_whiteSpaceAndComments)) |
-      ref0(_groupedExpression).trim(ref0(_whiteSpaceAndComments));
+  Parser _primaryExpression() => _PrimaryExpressionParser(
+    definition: this,
+    functionLiteral: ref0(_functionLiteral),
+    prefixExpression: ref0(_prefixExp),
+    numberLiteral: ref0(_numberLiteral),
+    stringLiteral: ref0(_stringLiteral),
+    tableConstructor: ref0(_tableConstructor),
+  );
 
   Parser _groupedExpression() => _span(
     (_token('(') & ref0(_expression) & _token(')')).map(
       (values) => GroupedExpression(values[1] as AstNode),
     ),
   );
-
-  Parser _nilLiteral() => position()
-      .seq(_token('nil'))
-      .seq(position())
-      .map((vals) => _annotate(NilValue(), vals[0] as int, vals[2] as int));
-
-  Parser _booleanLiteral() {
-    final trueLit = position()
-        .seq(_token('true'))
-        .seq(position())
-        .map(
-          (vals) =>
-              _annotate(BooleanLiteral(true), vals[0] as int, vals[2] as int),
-        );
-
-    final falseLit = position()
-        .seq(_token('false'))
-        .seq(position())
-        .map(
-          (vals) =>
-              _annotate(BooleanLiteral(false), vals[0] as int, vals[2] as int),
-        );
-
-    return trueLit | falseLit;
-  }
 
   // In Lua, an expression statement is only valid when the expression is
   // a function call or a method call (or vararg “...” which we treat as
@@ -541,252 +357,192 @@ class LuaGrammarDefinition extends GrammarDefinition {
   // grammar (§3.3.1).
 
   Parser _returnlessExprStatement() {
-    // Lua allows an *expression statement* only when the expression is a
-    // function- or method-call (see Lua 5.4 §3.3.1).  We implement this by
-    // first performing a non-consuming look-ahead that succeeds **only** if
-    // the upcoming expression parses to a FunctionCall/MethodCall AST node.
-
-    // Positive look-ahead (does not consume input).
-    final callAhead = ref0(
-      _prefixExp,
-    ).where((n) => n is FunctionCall || n is MethodCall).and();
-
-    // Real statement: full expression → ExpressionStatement with span.
-    final callStmt = _span(
-      ref0(_expression).map((expr) => ExpressionStatement(expr)),
+    // Lua allows an expression statement only when the expression is a
+    // function- or method-call (see Lua 5.4 §3.3.1).
+    return _ReturnlessExpressionStatementParser(
+      definition: this,
+      prefixExpression: ref0(_prefixExp),
     );
-
-    // Combine: require look-ahead, then parse the actual statement, keep it.
-    return (callAhead & callStmt).pick(1);
   }
 
   // ----------------- Literals ---------------------------------------------
 
-  // String literal parser that supports escape sequences (" ")
-  Parser _stringLiteral() {
-    // Helper to build content parser for given quote char
-    Parser contentParser(String quote) {
-      // Either an escaped character (\\X) or any char except the closing quote
-      return ((char('\\') & any()) | pattern('^$quote')).star().flatten();
-    }
+  // String literal parser that supports escape sequences.
+  Parser _stringLiteral() => _StringLiteralParser(this);
 
-    // Tag each alternative so we know if it's a long string.
-    final long = _LongBracketParser().map((s) => ['long', s]);
+  StringLiteral _longStringLiteral(String content, int start, int end) =>
+      _annotate(StringLiteral(content, isLongString: true), start, end);
 
-    // Closed short strings
-    final dq = (char('"') & contentParser('"') & char('"')).flatten().map(
-      (s) => ['dq', s],
-    );
-    final sq = (char("'") & contentParser("'") & char("'")).flatten().map(
-      (s) => ['sq', s],
-    );
-
-    // Unterminated short strings: start quote + content, but NOT followed by a closing quote
-    final dqUnclosed = (char('"') & contentParser('"') & char('"').not())
-        .flatten()
-        .map((s) => ['dq_unclosed', s]);
-    final sqUnclosed = (char("'") & contentParser("'") & char("'").not())
-        .flatten()
-        .map((s) => ['sq_unclosed', s]);
-
-    final literalBody = (long | dq | sq | dqUnclosed | sqUnclosed);
-
-    return position().seq(literalBody).seq(position()).trim(ref0(_whiteSpaceAndComments)).map((
-      vals,
-    ) {
-      final start = vals[0] as int;
-      final tagged = vals[1] as List;
-      final tag = tagged[0] as String;
-      final lexeme = tagged[1] as String;
-      final end = vals[2] as int;
-
-      if (tag == 'long') {
-        // lexeme is already the raw content.
-        return _annotate(StringLiteral(lexeme, isLongString: true), start, end);
-      } else if (tag == 'dq_unclosed' || tag == 'sq_unclosed') {
-        // Remove the starting quote only; there is no closing quote.
-        final content = lexeme.substring(1);
-
-        // Pre-validate content to surface escape-sequence errors before EOF
-        try {
-          LuaStringParser.parseStringContent(content);
-          // If validation passes, it's an unfinished string
-          throw _createPositionedException(
-            start,
-            "unfinished string near '<eof>'",
-          );
-        } catch (e) {
-          if (e is FormatException) {
-            // Convert detailed error message for escape sequence errors
-            String errorMessage = e.message;
-            if (errorMessage.contains('hexadecimal digit expected')) {
-              // Prefer no closing quote in the preview for unfinished strings
-              final quotedString = '"$content';
-              errorMessage =
-                  "[string \"\"]:1: hexadecimal digit expected near '$quotedString'";
-            } else if (errorMessage.contains('invalid escape sequence')) {
-              final quotedString = '"$content'; // No closing quote
-              errorMessage =
-                  "[string \"\"]:1: invalid escape sequence near '$quotedString'";
-            } else if (errorMessage.contains('missing \'}\' near|context:')) {
-              // Unclosed string due to missing closing brace in \u{...}
-              // Reconstruct snippet from actual content without assuming a prefix.
-              final contextStart = errorMessage.indexOf('context:') + 8;
-              final rawContext = errorMessage.substring(contextStart);
-              final hasTrailingQuote = rawContext.endsWith('"');
-              final ctxCore = hasTrailingQuote
-                  ? rawContext.substring(0, rawContext.length - 1)
-                  : rawContext;
-              final needle = '\\$ctxCore';
-              final idx = content.indexOf(needle);
-              final snippet = (idx >= 0)
-                  ? (content.substring(0, idx) + needle)
-                  : ('\\$ctxCore');
-              errorMessage = "[string \"\"]:1: missing '}' near '$snippet'";
-            } else if (errorMessage.startsWith('[string')) {
-              // Already formatted upstream
-            } else {
-              // Fallback to unfinished string
-              errorMessage = "[string \"\"]:1: unfinished string near '<eof>'";
-            }
-            throw _createPositionedException(start, errorMessage);
-          }
-          rethrow;
+  Never _throwUnfinishedShortString(String content, int start) {
+    // Pre-validate content to surface escape-sequence errors before EOF.
+    try {
+      LuaStringParser.parseStringContent(content);
+      throw _createPositionedException(start, "unfinished string near '<eof>'");
+    } catch (e) {
+      if (e is FormatException) {
+        // Convert detailed error message for escape sequence errors.
+        String errorMessage = e.message;
+        if (errorMessage.contains('hexadecimal digit expected')) {
+          final quotedString = '"$content';
+          errorMessage =
+              "[string \"\"]:1: hexadecimal digit expected near '$quotedString'";
+        } else if (errorMessage.contains('invalid escape sequence')) {
+          final quotedString = '"$content';
+          errorMessage =
+              "[string \"\"]:1: invalid escape sequence near '$quotedString'";
+        } else if (errorMessage.contains('missing \'}\' near|context:')) {
+          final contextStart = errorMessage.indexOf('context:') + 8;
+          final rawContext = errorMessage.substring(contextStart);
+          final hasTrailingQuote = rawContext.endsWith('"');
+          final ctxCore = hasTrailingQuote
+              ? rawContext.substring(0, rawContext.length - 1)
+              : rawContext;
+          final needle = '\\$ctxCore';
+          final idx = content.indexOf(needle);
+          final snippet = (idx >= 0)
+              ? (content.substring(0, idx) + needle)
+              : ('\\$ctxCore');
+          errorMessage = "[string \"\"]:1: missing '}' near '$snippet'";
+        } else if (!errorMessage.startsWith('[string')) {
+          errorMessage = "[string \"\"]:1: unfinished string near '<eof>'";
         }
-      } else {
-        // Closed short strings
-        final content = lexeme.substring(1, lexeme.length - 1);
-        // Normalize \xHH to decimal escapes to work around parser
-        // differences while preserving exact byte values.
-        String normalizeHexEscapes(String s) {
-          final re = RegExp(r'\\x([0-9A-Fa-f]{2})');
-          return s.replaceAllMapped(re, (m) {
-            final value = int.parse(m.group(1)!, radix: 16);
-            return '\\$value';
-          });
-        }
-
-        final normalized = normalizeHexEscapes(content);
-
-        // Pre-validate string content for escape sequence errors
-        try {
-          LuaStringParser.parseStringContent(normalized);
-        } catch (e) {
-          if (e is FormatException) {
-            // Convert detailed error message for escape sequence errors
-            String errorMessage = e.message;
-            if (errorMessage.contains('hexadecimal digit expected')) {
-              if (errorMessage.contains('|invalid')) {
-                errorMessage = errorMessage.replaceAll('|invalid', '');
-                final quotedString = '"$content';
-                errorMessage =
-                    "[string \"\"]:1: $errorMessage near '$quotedString'";
-              } else if (errorMessage.contains('|incomplete')) {
-                errorMessage = errorMessage.replaceAll('|incomplete', '');
-                final quotedString = '"$content"';
-                errorMessage =
-                    "[string \"\"]:1: $errorMessage near '$quotedString'";
-              } else {
-                final quotedString = '"$content"';
-                errorMessage =
-                    "[string \"\"]:1: hexadecimal digit expected near '$quotedString'";
-              }
-            } else if (errorMessage.contains('invalid escape sequence')) {
-              // For general invalid escape sequences like \g
-              final quotedString =
-                  '"$content'; // No closing quote for invalid escapes
-              errorMessage =
-                  "[string \"\"]:1: invalid escape sequence near '$quotedString'";
-            } else if (errorMessage.contains('decimal escape too large')) {
-              // For decimal escape sequences that are out of range
-              final quotedString = '"$content"';
-              errorMessage =
-                  "[string \"\"]:1: decimal escape too large near '$quotedString'";
-            } else if (errorMessage.contains(
-              'UTF-8 value too large|context:',
-            )) {
-              // Use provided context to reconstruct snippet without the
-              // closing '}'. This matches Lua's CLI output.
-              final contextStart = errorMessage.indexOf('context:') + 8;
-              final ctx = errorMessage.substring(
-                contextStart,
-              ); // e.g. u{100000000
-              final needle = '\\$ctx';
-              final idx = content.indexOf(needle);
-              final snippet = (idx >= 0)
-                  ? (content.substring(0, idx) + needle)
-                  : ('\\$ctx');
-              errorMessage =
-                  "[string \"\"]:1: UTF-8 value too large near '$snippet'";
-            } else if (errorMessage.contains('UTF-8 value too large')) {
-              // Generic too-large case
-              errorMessage =
-                  "[string \"\"]:1: UTF-8 value too large near '$content'";
-            } else if (errorMessage.contains('missing \'{\' near|context:')) {
-              // For \u escape sequences missing opening brace
-              final contextStart = errorMessage.indexOf('context:') + 8;
-              final rawContext = errorMessage.substring(contextStart);
-              final hasTrailingQuote = rawContext.endsWith('"');
-              final ctxCore = hasTrailingQuote
-                  ? rawContext.substring(0, rawContext.length - 1)
-                  : rawContext;
-              final needle = '\\$ctxCore';
-              final idx = content.indexOf(needle);
-              final snippet = (idx >= 0)
-                  ? (content.substring(0, idx) +
-                        needle +
-                        (hasTrailingQuote ? '"' : ''))
-                  : ('\\$rawContext');
-              errorMessage = "[string \"\"]:1: missing '{' near '$snippet'";
-            } else if (errorMessage.contains('missing \'}\' near|context:')) {
-              // For \u{ escape sequences missing closing brace
-              final contextStart = errorMessage.indexOf('context:') + 8;
-              final rawContext = errorMessage.substring(contextStart);
-              final hasTrailingQuote = rawContext.endsWith('"');
-              final ctxCore = hasTrailingQuote
-                  ? rawContext.substring(0, rawContext.length - 1)
-                  : rawContext;
-              final needle = '\\$ctxCore';
-              final idx = content.indexOf(needle);
-              final snippet = (idx >= 0)
-                  ? (content.substring(0, idx) +
-                        needle +
-                        (hasTrailingQuote ? '"' : ''))
-                  : ('\\$rawContext');
-              errorMessage = "[string \"\"]:1: missing '}' near '$snippet'";
-            } else if (errorMessage.contains(
-              'hexadecimal digit expected near|context:',
-            )) {
-              // For \u{ escape sequences with no hex digits
-              final contextStart = errorMessage.indexOf('context:') + 8;
-              final rawContext = errorMessage.substring(contextStart);
-              final hasTrailingQuote = rawContext.endsWith('"');
-              final ctxCore = hasTrailingQuote
-                  ? rawContext.substring(0, rawContext.length - 1)
-                  : rawContext;
-              final needle = '\\$ctxCore';
-              final idx = content.indexOf(needle);
-              final snippet = (idx >= 0)
-                  ? (content.substring(0, idx) +
-                        needle +
-                        (hasTrailingQuote ? '"' : ''))
-                  : ('\\$rawContext');
-              errorMessage =
-                  "[string \"\"]:1: hexadecimal digit expected near '$snippet'";
-            }
-            throw _createPositionedException(start, errorMessage);
-          }
-          rethrow;
-        }
-
-        // Use normalized content so downstream parsing yields correct bytes
-        return _annotate(StringLiteral(normalized), start, end);
+        throw _createPositionedException(start, errorMessage);
       }
-    });
+      rethrow;
+    }
   }
 
-  // vararg '...'
-  Parser _vararg() => _token('...').map((_) => VarArg());
+  StringLiteral _shortStringLiteral(
+    String content,
+    int start,
+    int end, {
+    required bool hasEscape,
+    required bool hasRawNewline,
+  }) {
+    if (!hasEscape && !hasRawNewline) {
+      return _annotate(
+        StringLiteral.withParsedBytes(content, convert.utf8.encode(content)),
+        start,
+        end,
+      );
+    }
+
+    final normalized = _normalizeHexEscapes(content);
+
+    late final List<int> bytes;
+    try {
+      bytes = LuaStringParser.parseStringContent(normalized);
+    } catch (e) {
+      if (e is FormatException) {
+        // Convert detailed error message for escape sequence errors.
+        String errorMessage = e.message;
+        if (errorMessage.contains('hexadecimal digit expected')) {
+          if (errorMessage.contains('|invalid')) {
+            errorMessage = errorMessage.replaceAll('|invalid', '');
+            final quotedString = '"$content';
+            errorMessage =
+                "[string \"\"]:1: $errorMessage near '$quotedString'";
+          } else if (errorMessage.contains('|incomplete')) {
+            errorMessage = errorMessage.replaceAll('|incomplete', '');
+            final quotedString = '"$content"';
+            errorMessage =
+                "[string \"\"]:1: $errorMessage near '$quotedString'";
+          } else {
+            final quotedString = '"$content"';
+            errorMessage =
+                "[string \"\"]:1: hexadecimal digit expected near '$quotedString'";
+          }
+        } else if (errorMessage.contains('invalid escape sequence')) {
+          final quotedString = '"$content';
+          errorMessage =
+              "[string \"\"]:1: invalid escape sequence near '$quotedString'";
+        } else if (errorMessage.contains('decimal escape too large')) {
+          final quotedString = '"$content"';
+          errorMessage =
+              "[string \"\"]:1: decimal escape too large near '$quotedString'";
+        } else if (errorMessage.contains('UTF-8 value too large|context:')) {
+          final contextStart = errorMessage.indexOf('context:') + 8;
+          final ctx = errorMessage.substring(contextStart);
+          final needle = '\\$ctx';
+          final idx = content.indexOf(needle);
+          final snippet = (idx >= 0)
+              ? (content.substring(0, idx) + needle)
+              : ('\\$ctx');
+          errorMessage =
+              "[string \"\"]:1: UTF-8 value too large near '$snippet'";
+        } else if (errorMessage.contains('UTF-8 value too large')) {
+          errorMessage =
+              "[string \"\"]:1: UTF-8 value too large near '$content'";
+        } else if (errorMessage.contains('missing \'{\' near|context:')) {
+          final contextStart = errorMessage.indexOf('context:') + 8;
+          final rawContext = errorMessage.substring(contextStart);
+          final hasTrailingQuote = rawContext.endsWith('"');
+          final ctxCore = hasTrailingQuote
+              ? rawContext.substring(0, rawContext.length - 1)
+              : rawContext;
+          final needle = '\\$ctxCore';
+          final idx = content.indexOf(needle);
+          final snippet = (idx >= 0)
+              ? (content.substring(0, idx) +
+                    needle +
+                    (hasTrailingQuote ? '"' : ''))
+              : ('\\$rawContext');
+          errorMessage = "[string \"\"]:1: missing '{' near '$snippet'";
+        } else if (errorMessage.contains('missing \'}\' near|context:')) {
+          final contextStart = errorMessage.indexOf('context:') + 8;
+          final rawContext = errorMessage.substring(contextStart);
+          final hasTrailingQuote = rawContext.endsWith('"');
+          final ctxCore = hasTrailingQuote
+              ? rawContext.substring(0, rawContext.length - 1)
+              : rawContext;
+          final needle = '\\$ctxCore';
+          final idx = content.indexOf(needle);
+          final snippet = (idx >= 0)
+              ? (content.substring(0, idx) +
+                    needle +
+                    (hasTrailingQuote ? '"' : ''))
+              : ('\\$rawContext');
+          errorMessage = "[string \"\"]:1: missing '}' near '$snippet'";
+        } else if (errorMessage.contains(
+          'hexadecimal digit expected near|context:',
+        )) {
+          final contextStart = errorMessage.indexOf('context:') + 8;
+          final rawContext = errorMessage.substring(contextStart);
+          final hasTrailingQuote = rawContext.endsWith('"');
+          final ctxCore = hasTrailingQuote
+              ? rawContext.substring(0, rawContext.length - 1)
+              : rawContext;
+          final needle = '\\$ctxCore';
+          final idx = content.indexOf(needle);
+          final snippet = (idx >= 0)
+              ? (content.substring(0, idx) +
+                    needle +
+                    (hasTrailingQuote ? '"' : ''))
+              : ('\\$rawContext');
+          errorMessage =
+              "[string \"\"]:1: hexadecimal digit expected near '$snippet'";
+        }
+        throw _createPositionedException(start, errorMessage);
+      }
+      rethrow;
+    }
+
+    return _annotate(
+      StringLiteral.withParsedBytes(normalized, bytes),
+      start,
+      end,
+    );
+  }
+
+  String _normalizeHexEscapes(String content) {
+    if (!content.contains(r'\x')) {
+      return content;
+    }
+    return content.replaceAllMapped(_hexEscapePattern, (m) {
+      final value = int.parse(m.group(1)!, radix: 16);
+      return '\\$value';
+    });
+  }
 
   // ----------------- Table constructors -----------------------------------
 
@@ -812,34 +568,8 @@ class LuaGrammarDefinition extends GrammarDefinition {
 
   Parser _fieldsep() => _token(',') | _token(';');
 
-  Parser _field() {
-    // 1. [exp] = exp
-    final indexed =
-        (_token('[') &
-                ref0(_expression) &
-                _token(']') &
-                _token('=') &
-                ref0(_expression))
-            .map((values) {
-              final key = values[1] as AstNode;
-              final val = values[4] as AstNode;
-              return IndexedTableEntry(key, val);
-            });
-
-    // 2. Name = exp
-    final keyed = (_identifier() & _token('=') & ref0(_expression)).map((
-      values,
-    ) {
-      final nameId = values[0] as Identifier;
-      final val = values[2] as AstNode;
-      return KeyedTableEntry(nameId, val);
-    });
-
-    // 3. exp
-    final literal = ref0(_expression).map((expr) => TableEntryLiteral(expr));
-
-    return indexed | keyed | literal;
-  }
+  Parser _field() =>
+      _FieldParser(expression: ref0(_expression), identifier: _identifier());
 
   // prefixexp ::= var | functioncall | '(' exp ')'
   Parser _prefixExp() {
@@ -849,56 +579,40 @@ class LuaGrammarDefinition extends GrammarDefinition {
 
     return (base & suffix).map((values) {
       AstNode expr = values[0] as AstNode;
-      final List<dynamic> sufs = values[1] as List;
+      final sufs = (values[1] as List).cast<_PrefixSuffix>();
       for (final s in sufs) {
-        final type = s[0] as String;
-        switch (type) {
-          case 'index':
-            final access = TableIndexAccess(expr, s[1] as AstNode);
-            access.setSpan(expr.span ?? _sourceFile.span(0, 0));
-            expr = access;
-            break;
-          case 'field':
-            final access = TableFieldAccess(expr, s[1] as Identifier);
-            access.setSpan(expr.span ?? _sourceFile.span(0, 0));
-            expr = access;
-            break;
-          case 'call':
-            final args = (s[1] as List).cast<AstNode>();
-            final call = FunctionCall(expr, args);
-            call.setSpan(expr.span ?? _sourceFile.span(0, 0));
-            expr = call;
-            break;
-          case 'method':
-            final id = s[1] as Identifier;
-            final args = (s[2] as List).cast<AstNode>();
-            final mcall = MethodCall(expr, id, args, implicitSelf: true);
-            mcall.setSpan(expr.span ?? _sourceFile.span(0, 0));
-            expr = mcall;
-            break;
+        if (s is _IndexSuffix) {
+          final access = TableIndexAccess(expr, s.expression);
+          access.setSpan(expr.span ?? _sourceFile.span(0, 0));
+          expr = access;
+        } else if (s is _FieldSuffix) {
+          final access = TableFieldAccess(expr, s.identifier);
+          access.setSpan(expr.span ?? _sourceFile.span(0, 0));
+          expr = access;
+        } else if (s is _CallSuffix) {
+          final call = FunctionCall(expr, s.args);
+          call.setSpan(expr.span ?? _sourceFile.span(0, 0));
+          expr = call;
+        } else if (s is _MethodSuffix) {
+          final mcall = MethodCall(
+            expr,
+            s.identifier,
+            s.args,
+            implicitSelf: true,
+          );
+          mcall.setSpan(expr.span ?? _sourceFile.span(0, 0));
+          expr = mcall;
         }
       }
       return expr;
     });
   }
 
-  Parser _suffix() {
-    // index
-    final index = (_token('[') & ref0(_expression) & _token(']')).map(
-      (vals) => ['index', vals[1]],
-    );
-    // field .Name
-    final field = (_token('.') & _identifier()).map(
-      (vals) => ['field', vals[1]],
-    );
-    // method call :Name args
-    final method = (_token(':') & _identifier() & ref0(_args)).map(
-      (vals) => ['method', vals[1], vals[2]],
-    );
-    // function call args
-    final call = ref0(_args).map((a) => ['call', a]);
-    return index | field | method | call;
-  }
+  Parser _suffix() => _SuffixParser(
+    expression: ref0(_expression),
+    identifier: _identifier(),
+    args: ref0(_args),
+  );
 
   // args ::= '(' [explist] ')' | tableconstructor | LiteralString
   Parser _args() {
@@ -1149,41 +863,39 @@ class LuaGrammarDefinition extends GrammarDefinition {
   // ----------------- Expression helpers for correct '^' precedence -------
 
   // Parses unary prefix operators and builds nested UnaryExpression nodes.
-  Parser _unaryExpression() {
-    final unarySeq = (ref0(_unaryOperatorToken).plus() & ref0(_powerExpression))
-        .map((vals) {
-          final ops = vals[0] as List;
-          AstNode node = vals[1] as AstNode;
-          for (var i = ops.length - 1; i >= 0; i--) {
-            final opSpec = ops[i];
-            final op = switch (opSpec) {
-              String value => value,
-              ({String op, int line, int offset}) value => value.op,
-              _ => opSpec.toString(),
-            };
-            final operatorLine = switch (opSpec) {
-              ({String op, int line, int offset}) value => value.line,
-              _ => null,
-            };
-            final operatorOffset = switch (opSpec) {
-              ({String op, int line, int offset}) value => value.offset,
-              _ => null,
-            };
-            final unary = UnaryExpression(op, node, operatorLine: operatorLine);
-            if (operatorOffset != null && node.span != null) {
-              unary.setSpan(
-                _sourceFile.span(operatorOffset, node.span!.end.offset),
-              );
-            } else if (node.span != null) {
-              unary.setSpan(node.span!);
-            }
-            node = unary;
-          }
-          return node;
-        });
+  Parser _unaryExpression() =>
+      _UnaryExpressionParser(this, ref0(_powerExpression));
 
-    // If there is no unary operator, just parse the power expression.
-    return unarySeq | ref0(_powerExpression);
+  _UnaryOperatorMatch? _matchUnaryOperator(String buffer, int position) {
+    final start = _skipLuaTrivia(buffer, position);
+    if (start >= buffer.length) {
+      return null;
+    }
+
+    _UnaryOperatorMatch match(String lexeme) => _UnaryOperatorMatch(
+      lexeme: lexeme,
+      offset: start,
+      end: _skipLuaTrivia(buffer, start + lexeme.length),
+    );
+
+    switch (buffer.codeUnitAt(start)) {
+      case 0x2D: // -
+        return match('-');
+      case 0x23: // #
+        return match('#');
+      case 0x7E: // ~
+        return match('~');
+      case 0x6E: // n
+        const lexeme = 'not';
+        final rawEnd = start + lexeme.length;
+        if (_matchesLexeme(buffer, start, lexeme) &&
+            (rawEnd >= buffer.length ||
+                !_isIdentifierContinueCodeUnit(buffer.codeUnitAt(rawEnd)))) {
+          return match(lexeme);
+        }
+    }
+
+    return null;
   }
 
   // Parses a chain of '^' operators with right associativity. The right-hand
@@ -1210,10 +922,20 @@ class LuaGrammarDefinition extends GrammarDefinition {
     return (position() & tokenParser).map((vals) {
       final offset = vals[0] as int;
       final op = vals[1] as String;
-      final line = _sourceFile.location(offset).line;
-      return (op: op, line: line);
+      return (op: op, offset: offset);
     });
   }
+
+  int? _binaryOperatorLine(dynamic opSpec) => switch (opSpec) {
+    ({String op, int line}) value => value.line,
+    ({String op, int offset}) value => _sourceFile.location(value.offset).line,
+    _ => null,
+  };
+
+  int? _binaryOperatorOffset(dynamic opSpec) => switch (opSpec) {
+    ({String op, int offset}) value => value.offset,
+    _ => null,
+  };
 
   BinaryExpression _makeBinaryExpression(
     AstNode left,
@@ -1223,30 +945,40 @@ class LuaGrammarDefinition extends GrammarDefinition {
     final op = switch (opSpec) {
       String value => value,
       ({String op, int line}) value => value.op,
+      ({String op, int offset}) value => value.op,
       _ => opSpec.toString(),
     };
-    final operatorLine = switch (opSpec) {
-      ({String op, int line}) value => value.line,
-      _ => null,
-    };
-    int? adjustedOperatorLine = operatorLine;
+
+    final operatorOffset = _binaryOperatorOffset(opSpec);
+    var adjustedOperatorLine = operatorOffset == null
+        ? null
+        : _sourceFile.location(operatorOffset).line;
+    var fallbackOperatorLineResolved = operatorOffset != null;
     if (left.span != null && right.span != null) {
       final searchStart = left.span!.start.offset;
       final searchEnd = right.span!.start.offset;
-      if (searchStart <= searchEnd) {
+      if (operatorOffset == null && searchStart <= searchEnd) {
         final betweenText = _sourceFile.span(searchStart, searchEnd).text;
         final opIndex = betweenText.lastIndexOf(op);
         if (opIndex >= 0) {
           adjustedOperatorLine = _sourceFile
               .location(searchStart + opIndex)
               .line;
-        } else if (adjustedOperatorLine != null &&
-            left.span!.start.line != right.span!.start.line &&
-            right.span!.start.line > left.span!.start.line + 1 &&
-            adjustedOperatorLine <= left.span!.start.line) {
-          adjustedOperatorLine = right.span!.start.line - 1;
+        } else {
+          final resolvedOperatorLine = _binaryOperatorLine(opSpec);
+          fallbackOperatorLineResolved = true;
+          adjustedOperatorLine = resolvedOperatorLine;
+          if (resolvedOperatorLine != null &&
+              left.span!.start.line != right.span!.start.line &&
+              right.span!.start.line > left.span!.start.line + 1 &&
+              resolvedOperatorLine <= left.span!.start.line) {
+            adjustedOperatorLine = right.span!.start.line - 1;
+          }
         }
       }
+    }
+    if (adjustedOperatorLine == null && !fallbackOperatorLineResolved) {
+      adjustedOperatorLine = _binaryOperatorLine(opSpec);
     }
 
     final node = BinaryExpression(
@@ -1387,6 +1119,1118 @@ class LuaGrammarDefinition extends GrammarDefinition {
   }
 }
 
+class _StringLiteralParser extends Parser<StringLiteral> {
+  _StringLiteralParser(this.definition);
+
+  final LuaGrammarDefinition definition;
+  final Parser<String> _longBracketParser = _LongBracketParser();
+
+  @override
+  Result<StringLiteral> parseOn(Context context) {
+    final buffer = context.buffer;
+    final start = _skipLuaTrivia(buffer, context.position);
+    if (start >= buffer.length) {
+      return context.failure('string literal expected');
+    }
+
+    final codeUnit = buffer.codeUnitAt(start);
+    if (codeUnit == 0x5B) {
+      return _parseLongString(context, buffer, start);
+    }
+    if (codeUnit == 0x22 || codeUnit == 0x27) {
+      return _parseShortString(context, buffer, start, codeUnit);
+    }
+    return context.failure('string literal expected', start);
+  }
+
+  Result<StringLiteral> _parseLongString(
+    Context context,
+    String buffer,
+    int start,
+  ) {
+    if (!_startsLongBracket(buffer, start)) {
+      return context.failure('string literal expected', start);
+    }
+
+    final result = _longBracketParser.parseOn(Context(buffer, start));
+    if (result is Failure) {
+      return context.failure(result.message, result.position);
+    }
+
+    final rawEnd = result.position;
+    final node = definition._longStringLiteral(result.value, start, rawEnd);
+    return context.success(node, _skipLuaTrivia(buffer, rawEnd));
+  }
+
+  Result<StringLiteral> _parseShortString(
+    Context context,
+    String buffer,
+    int start,
+    int quote,
+  ) {
+    var current = start + 1;
+    var hasEscape = false;
+    var hasRawNewline = false;
+    while (current < buffer.length) {
+      final codeUnit = buffer.codeUnitAt(current);
+      if (codeUnit == quote) {
+        final rawEnd = current + 1;
+        final content = buffer.substring(start + 1, current);
+        final node = definition._shortStringLiteral(
+          content,
+          start,
+          rawEnd,
+          hasEscape: hasEscape,
+          hasRawNewline: hasRawNewline,
+        );
+        return context.success(node, _skipLuaTrivia(buffer, rawEnd));
+      }
+      if (codeUnit == 0x5C && current + 1 < buffer.length) {
+        hasEscape = true;
+        current += 2;
+      } else {
+        if (codeUnit == 0x0A || codeUnit == 0x0D) {
+          hasRawNewline = true;
+        }
+        current++;
+      }
+    }
+
+    final content = buffer.substring(start + 1);
+    definition._throwUnfinishedShortString(content, start);
+  }
+
+  @override
+  _StringLiteralParser copy() => _StringLiteralParser(definition);
+}
+
+class _ExpressionListParser extends Parser<List<AstNode>> {
+  _ExpressionListParser(this.expression, this.comma);
+
+  Parser expression;
+  Parser comma;
+
+  @override
+  Result<List<AstNode>> parseOn(Context context) {
+    final firstResult = expression.parseOn(context);
+    if (firstResult is Failure) {
+      return firstResult;
+    }
+
+    final expressions = <AstNode>[firstResult.value as AstNode];
+    var current = firstResult.position;
+    final buffer = context.buffer;
+
+    while (true) {
+      final commaResult = comma.parseOn(Context(buffer, current));
+      if (commaResult is Failure) {
+        break;
+      }
+
+      final expressionResult = expression.parseOn(
+        Context(buffer, commaResult.position),
+      );
+      if (expressionResult is Failure) {
+        return expressionResult;
+      }
+      expressions.add(expressionResult.value as AstNode);
+      current = expressionResult.position;
+    }
+
+    return context.success(expressions, current);
+  }
+
+  @override
+  _ExpressionListParser copy() => _ExpressionListParser(expression, comma);
+
+  @override
+  List<Parser> get children => [expression, comma];
+
+  @override
+  void replace(Parser source, Parser target) {
+    super.replace(source, target);
+    if (expression == source) {
+      expression = target;
+    }
+    if (comma == source) {
+      comma = target;
+    }
+  }
+}
+
+class _FieldParser extends Parser<TableEntry> {
+  _FieldParser({required this.expression, required this.identifier});
+
+  Parser expression;
+  Parser identifier;
+
+  @override
+  Result<TableEntry> parseOn(Context context) {
+    final buffer = context.buffer;
+    final start = _skipLuaTrivia(buffer, context.position);
+    if (start >= buffer.length) {
+      return context.failure('table field expected', start);
+    }
+
+    if (buffer.codeUnitAt(start) == 0x5B &&
+        !_startsLongBracket(buffer, start)) {
+      final indexedResult = _parseIndexed(context, buffer, start);
+      if (indexedResult is Success<TableEntry>) {
+        return indexedResult;
+      }
+    }
+
+    if (_isIdentifierStartCodeUnit(buffer.codeUnitAt(start))) {
+      final keyedResult = _parseKeyed(context, buffer, start);
+      if (keyedResult is Success<TableEntry>) {
+        return keyedResult;
+      }
+    }
+
+    return _parseLiteral(context, buffer, start);
+  }
+
+  Result<TableEntry> _parseIndexed(Context context, String buffer, int start) {
+    final keyResult = expression.parseOn(
+      Context(buffer, _skipLuaTrivia(buffer, start + 1)),
+    );
+    if (keyResult is Failure) {
+      return keyResult;
+    }
+
+    final close = _skipLuaTrivia(buffer, keyResult.position);
+    if (close >= buffer.length || buffer.codeUnitAt(close) != 0x5D) {
+      return context.failure('"]" expected', close);
+    }
+
+    final equals = _skipLuaTrivia(buffer, close + 1);
+    if (equals >= buffer.length || buffer.codeUnitAt(equals) != 0x3D) {
+      return context.failure('"=" expected', equals);
+    }
+
+    final valueResult = expression.parseOn(
+      Context(buffer, _skipLuaTrivia(buffer, equals + 1)),
+    );
+    if (valueResult is Failure) {
+      return valueResult;
+    }
+
+    return context.success(
+      IndexedTableEntry(
+        keyResult.value as AstNode,
+        valueResult.value as AstNode,
+      ),
+      valueResult.position,
+    );
+  }
+
+  Result<TableEntry> _parseKeyed(Context context, String buffer, int start) {
+    final identifierResult = identifier.parseOn(Context(buffer, start));
+    if (identifierResult is Failure) {
+      return identifierResult;
+    }
+
+    final equals = _skipLuaTrivia(buffer, identifierResult.position);
+    if (equals >= buffer.length || buffer.codeUnitAt(equals) != 0x3D) {
+      return context.failure('"=" expected', equals);
+    }
+
+    final valueResult = expression.parseOn(
+      Context(buffer, _skipLuaTrivia(buffer, equals + 1)),
+    );
+    if (valueResult is Failure) {
+      return valueResult;
+    }
+
+    return context.success(
+      KeyedTableEntry(
+        identifierResult.value as Identifier,
+        valueResult.value as AstNode,
+      ),
+      valueResult.position,
+    );
+  }
+
+  Result<TableEntry> _parseLiteral(Context context, String buffer, int start) {
+    final result = expression.parseOn(Context(buffer, start));
+    if (result is Failure) {
+      return result;
+    }
+    return context.success(
+      TableEntryLiteral(result.value as AstNode),
+      result.position,
+    );
+  }
+
+  @override
+  _FieldParser copy() =>
+      _FieldParser(expression: expression, identifier: identifier);
+
+  @override
+  List<Parser> get children => [expression, identifier];
+
+  @override
+  void replace(Parser source, Parser target) {
+    super.replace(source, target);
+    if (expression == source) {
+      expression = target;
+    }
+    if (identifier == source) {
+      identifier = target;
+    }
+  }
+}
+
+sealed class _PrefixSuffix {
+  const _PrefixSuffix();
+}
+
+final class _IndexSuffix extends _PrefixSuffix {
+  const _IndexSuffix(this.expression);
+
+  final AstNode expression;
+}
+
+final class _FieldSuffix extends _PrefixSuffix {
+  const _FieldSuffix(this.identifier);
+
+  final Identifier identifier;
+}
+
+final class _CallSuffix extends _PrefixSuffix {
+  const _CallSuffix(this.args);
+
+  final List<AstNode> args;
+}
+
+final class _MethodSuffix extends _PrefixSuffix {
+  const _MethodSuffix(this.identifier, this.args);
+
+  final Identifier identifier;
+  final List<AstNode> args;
+}
+
+class _SuffixParser extends Parser<_PrefixSuffix> {
+  _SuffixParser({
+    required this.expression,
+    required this.identifier,
+    required this.args,
+  });
+
+  Parser expression;
+  Parser identifier;
+  Parser args;
+
+  @override
+  Result<_PrefixSuffix> parseOn(Context context) {
+    final buffer = context.buffer;
+    final start = _skipLuaTrivia(buffer, context.position);
+    if (start >= buffer.length) {
+      return context.failure('suffix expected');
+    }
+
+    switch (buffer.codeUnitAt(start)) {
+      case 0x5B: // [
+        if (_startsLongBracket(buffer, start)) {
+          return _parseCall(context, buffer, start);
+        }
+        return _parseIndex(context, buffer, start);
+      case 0x2E: // .
+        return _parseField(context, buffer, start);
+      case 0x3A: // :
+        return _parseMethod(context, buffer, start);
+      case 0x28: // (
+      case 0x7B: // {
+      case 0x22: // "
+      case 0x27: // '
+        return _parseCall(context, buffer, start);
+    }
+
+    return context.failure('suffix expected', start);
+  }
+
+  Result<_PrefixSuffix> _parseIndex(Context context, String buffer, int start) {
+    final expressionResult = expression.parseOn(
+      Context(buffer, _skipLuaTrivia(buffer, start + 1)),
+    );
+    if (expressionResult is Failure) {
+      return expressionResult;
+    }
+
+    final close = _skipLuaTrivia(buffer, expressionResult.position);
+    if (close >= buffer.length || buffer.codeUnitAt(close) != 0x5D) {
+      return context.failure('"]" expected', close);
+    }
+
+    return context.success(
+      _IndexSuffix(expressionResult.value as AstNode),
+      _skipLuaTrivia(buffer, close + 1),
+    );
+  }
+
+  Result<_PrefixSuffix> _parseField(Context context, String buffer, int start) {
+    final identifierResult = identifier.parseOn(
+      Context(buffer, _skipLuaTrivia(buffer, start + 1)),
+    );
+    if (identifierResult is Failure) {
+      return identifierResult;
+    }
+
+    return context.success(
+      _FieldSuffix(identifierResult.value as Identifier),
+      identifierResult.position,
+    );
+  }
+
+  Result<_PrefixSuffix> _parseMethod(
+    Context context,
+    String buffer,
+    int start,
+  ) {
+    final identifierResult = identifier.parseOn(
+      Context(buffer, _skipLuaTrivia(buffer, start + 1)),
+    );
+    if (identifierResult is Failure) {
+      return identifierResult;
+    }
+
+    final argsResult = args.parseOn(Context(buffer, identifierResult.position));
+    if (argsResult is Failure) {
+      return argsResult;
+    }
+
+    return context.success(
+      _MethodSuffix(
+        identifierResult.value as Identifier,
+        (argsResult.value as List).cast<AstNode>(),
+      ),
+      argsResult.position,
+    );
+  }
+
+  Result<_PrefixSuffix> _parseCall(Context context, String buffer, int start) {
+    final argsResult = args.parseOn(Context(buffer, start));
+    if (argsResult is Failure) {
+      return argsResult;
+    }
+    return context.success(
+      _CallSuffix((argsResult.value as List).cast<AstNode>()),
+      argsResult.position,
+    );
+  }
+
+  @override
+  _SuffixParser copy() =>
+      _SuffixParser(expression: expression, identifier: identifier, args: args);
+
+  @override
+  List<Parser> get children => [expression, identifier, args];
+
+  @override
+  void replace(Parser source, Parser target) {
+    super.replace(source, target);
+    if (expression == source) {
+      expression = target;
+    }
+    if (identifier == source) {
+      identifier = target;
+    }
+    if (args == source) {
+      args = target;
+    }
+  }
+}
+
+class _ReturnlessExpressionStatementParser extends Parser<ExpressionStatement> {
+  _ReturnlessExpressionStatementParser({
+    required this.definition,
+    required this.prefixExpression,
+  });
+
+  final LuaGrammarDefinition definition;
+  Parser prefixExpression;
+
+  @override
+  Result<ExpressionStatement> parseOn(Context context) {
+    final buffer = context.buffer;
+    final start = _skipLuaTrivia(buffer, context.position);
+    if (!_couldStartCallStatement(buffer, start)) {
+      return context.failure('function call expected', start);
+    }
+
+    final result = prefixExpression.parseOn(Context(buffer, start));
+    if (result is Failure) {
+      return result;
+    }
+
+    final expression = result.value as AstNode;
+    if (expression is! FunctionCall && expression is! MethodCall) {
+      return context.failure('function call expected', start);
+    }
+
+    final statement = ExpressionStatement(expression);
+    statement.setSpan(definition._sourceFile.span(start, result.position));
+    return context.success(statement, result.position);
+  }
+
+  bool _couldStartCallStatement(String buffer, int start) {
+    if (start >= buffer.length) {
+      return false;
+    }
+
+    final first = buffer.codeUnitAt(start);
+    if (first == 0x28) {
+      return true;
+    }
+    if (!_isIdentifierStartCodeUnit(first)) {
+      return false;
+    }
+
+    var current = _scanIdentifierEnd(buffer, start);
+    while (true) {
+      current = _skipLuaTrivia(buffer, current);
+      if (current >= buffer.length) {
+        return false;
+      }
+
+      switch (buffer.codeUnitAt(current)) {
+        case 0x28: // (
+        case 0x7B: // {
+        case 0x22: // "
+        case 0x27: // '
+          return true;
+        case 0x5B: // [
+          return true;
+        case 0x3A: // :
+          return true;
+        case 0x2E: // .
+          final nameStart = _skipLuaTrivia(buffer, current + 1);
+          if (nameStart >= buffer.length ||
+              !_isIdentifierStartCodeUnit(buffer.codeUnitAt(nameStart))) {
+            return false;
+          }
+          current = _scanIdentifierEnd(buffer, nameStart);
+          continue;
+      }
+
+      return false;
+    }
+  }
+
+  @override
+  _ReturnlessExpressionStatementParser copy() =>
+      _ReturnlessExpressionStatementParser(
+        definition: definition,
+        prefixExpression: prefixExpression,
+      );
+
+  @override
+  List<Parser> get children => [prefixExpression];
+
+  @override
+  void replace(Parser source, Parser target) {
+    super.replace(source, target);
+    if (prefixExpression == source) {
+      prefixExpression = target;
+    }
+  }
+}
+
+class _PrimaryExpressionParser extends Parser<AstNode> {
+  _PrimaryExpressionParser({
+    required this.definition,
+    required this.functionLiteral,
+    required this.prefixExpression,
+    required this.numberLiteral,
+    required this.stringLiteral,
+    required this.tableConstructor,
+  });
+
+  final LuaGrammarDefinition definition;
+  Parser functionLiteral;
+  Parser prefixExpression;
+  Parser numberLiteral;
+  Parser stringLiteral;
+  Parser tableConstructor;
+
+  @override
+  Result<AstNode> parseOn(Context context) {
+    final buffer = context.buffer;
+    final start = _skipLuaTrivia(buffer, context.position);
+    if (start >= buffer.length) {
+      return context.failure('primary expression expected');
+    }
+
+    final literalResult = _parseDirectLiteral(context, buffer, start);
+    if (literalResult != null) {
+      return literalResult;
+    }
+
+    final parser = _selectParser(buffer, start);
+    if (parser == null) {
+      return context.failure('primary expression expected', start);
+    }
+
+    final result = parser.parseOn(Context(buffer, start));
+    if (result is Failure) {
+      return result;
+    }
+    return context.success(result.value as AstNode, result.position);
+  }
+
+  Result<AstNode>? _parseDirectLiteral(
+    Context context,
+    String buffer,
+    int start,
+  ) {
+    final codeUnit = buffer.codeUnitAt(start);
+    if (codeUnit == 0x2E && _matchesLexeme(buffer, start, '...')) {
+      return context.success(VarArg(), _skipLuaTrivia(buffer, start + 3));
+    }
+    if (codeUnit == 0x66 && _matchesKeywordLexeme(buffer, start, 'false')) {
+      return _literalSuccess(context, BooleanLiteral(false), start, 5);
+    }
+    if (codeUnit == 0x6E && _matchesKeywordLexeme(buffer, start, 'nil')) {
+      return _literalSuccess(context, NilValue(), start, 3);
+    }
+    if (codeUnit == 0x74 && _matchesKeywordLexeme(buffer, start, 'true')) {
+      return _literalSuccess(context, BooleanLiteral(true), start, 4);
+    }
+    return null;
+  }
+
+  Result<AstNode> _literalSuccess(
+    Context context,
+    AstNode node,
+    int start,
+    int rawLength,
+  ) {
+    final end = _skipLuaTrivia(context.buffer, start + rawLength);
+    node.setSpan(definition._sourceFile.span(start, end));
+    return context.success(node, end);
+  }
+
+  Parser? _selectParser(String buffer, int start) {
+    final codeUnit = buffer.codeUnitAt(start);
+    if (codeUnit == 0x28) {
+      return prefixExpression;
+    }
+    if (codeUnit == 0x7B) {
+      return tableConstructor;
+    }
+    if (codeUnit == 0x22 || codeUnit == 0x27) {
+      return stringLiteral;
+    }
+    if (codeUnit == 0x5B) {
+      return _startsLongBracket(buffer, start) ? stringLiteral : null;
+    }
+    if (codeUnit == 0x2E) {
+      return start + 1 < buffer.length &&
+              _isDigitCodeUnit(buffer.codeUnitAt(start + 1))
+          ? numberLiteral
+          : null;
+    }
+    if (_isDigitCodeUnit(codeUnit)) {
+      return numberLiteral;
+    }
+    if (_matchesKeywordLexeme(buffer, start, 'function')) {
+      return functionLiteral;
+    }
+    return _isIdentifierStartCodeUnit(codeUnit) ? prefixExpression : null;
+  }
+
+  @override
+  _PrimaryExpressionParser copy() => _PrimaryExpressionParser(
+    definition: definition,
+    functionLiteral: functionLiteral,
+    prefixExpression: prefixExpression,
+    numberLiteral: numberLiteral,
+    stringLiteral: stringLiteral,
+    tableConstructor: tableConstructor,
+  );
+
+  @override
+  List<Parser> get children => [
+    functionLiteral,
+    prefixExpression,
+    numberLiteral,
+    stringLiteral,
+    tableConstructor,
+  ];
+
+  @override
+  void replace(Parser source, Parser target) {
+    super.replace(source, target);
+    if (functionLiteral == source) {
+      functionLiteral = target;
+    }
+    if (prefixExpression == source) {
+      prefixExpression = target;
+    }
+    if (numberLiteral == source) {
+      numberLiteral = target;
+    }
+    if (stringLiteral == source) {
+      stringLiteral = target;
+    }
+    if (tableConstructor == source) {
+      tableConstructor = target;
+    }
+  }
+}
+
+class _UnaryExpressionParser extends Parser<AstNode> {
+  _UnaryExpressionParser(this.definition, this.powerExpression);
+
+  final LuaGrammarDefinition definition;
+  Parser powerExpression;
+
+  @override
+  Result<AstNode> parseOn(Context context) {
+    final buffer = context.buffer;
+    final firstOperator = definition._matchUnaryOperator(
+      buffer,
+      context.position,
+    );
+    if (firstOperator == null) {
+      final result = powerExpression.parseOn(context);
+      if (result is Failure) {
+        return result;
+      }
+      return context.success(result.value as AstNode, result.position);
+    }
+
+    var current = firstOperator.end;
+    final operators = <_UnaryOperatorMatch>[firstOperator];
+    while (true) {
+      final operator = definition._matchUnaryOperator(buffer, current);
+      if (operator == null) {
+        break;
+      }
+      operators.add(operator);
+      current = operator.end;
+    }
+
+    final powerResult = powerExpression.parseOn(Context(buffer, current));
+    if (powerResult is Failure) {
+      return powerResult;
+    }
+
+    var node = powerResult.value as AstNode;
+    for (var i = operators.length - 1; i >= 0; i--) {
+      final operator = operators[i];
+      final unary = UnaryExpression(
+        operator.lexeme,
+        node,
+        operatorLine: definition._sourceFile.location(operator.offset).line,
+      );
+      if (node.span != null) {
+        unary.setSpan(
+          definition._sourceFile.span(operator.offset, node.span!.end.offset),
+        );
+      }
+      node = unary;
+    }
+
+    return context.success(node, powerResult.position);
+  }
+
+  @override
+  _UnaryExpressionParser copy() =>
+      _UnaryExpressionParser(definition, powerExpression);
+
+  @override
+  List<Parser> get children => [powerExpression];
+
+  @override
+  void replace(Parser source, Parser target) {
+    super.replace(source, target);
+    if (powerExpression == source) {
+      powerExpression = target;
+    }
+  }
+}
+
+final class _UnaryOperatorMatch {
+  const _UnaryOperatorMatch({
+    required this.lexeme,
+    required this.offset,
+    required this.end,
+  });
+
+  final String lexeme;
+  final int offset;
+  final int end;
+}
+
+class _ExpressionParser extends Parser<AstNode> {
+  _ExpressionParser(this.definition, this.operand);
+
+  final LuaGrammarDefinition definition;
+  Parser operand;
+
+  @override
+  Result<AstNode> parseOn(Context context) => _parseExpression(context, 1);
+
+  Result<AstNode> _parseExpression(Context context, int minimumPrecedence) {
+    var leftResult = operand.parseOn(context);
+    if (leftResult is Failure) {
+      return leftResult;
+    }
+
+    var left = leftResult.value as AstNode;
+    var current = leftResult.position;
+    final buffer = context.buffer;
+
+    while (true) {
+      final operator = _matchBinaryOperator(buffer, current);
+      if (operator == null || operator.precedence < minimumPrecedence) {
+        break;
+      }
+
+      final rightMinimumPrecedence = operator.rightAssociative
+          ? operator.precedence
+          : operator.precedence + 1;
+      final rightResult = _parseExpression(
+        Context(buffer, operator.end),
+        rightMinimumPrecedence,
+      );
+      if (rightResult is Failure) {
+        return rightResult;
+      }
+
+      left = definition._makeBinaryExpression(left, (
+        op: operator.lexeme,
+        offset: operator.offset,
+      ), rightResult.value);
+      current = rightResult.position;
+    }
+
+    return context.success(left, current);
+  }
+
+  @override
+  _ExpressionParser copy() => _ExpressionParser(definition, operand);
+
+  @override
+  List<Parser> get children => [operand];
+
+  @override
+  void replace(Parser source, Parser target) {
+    super.replace(source, target);
+    if (operand == source) {
+      operand = target;
+    }
+  }
+}
+
+final class _BinaryOperatorMatch {
+  const _BinaryOperatorMatch({
+    required this.lexeme,
+    required this.offset,
+    required this.end,
+    required this.precedence,
+    required this.rightAssociative,
+  });
+
+  final String lexeme;
+  final int offset;
+  final int end;
+  final int precedence;
+  final bool rightAssociative;
+}
+
+_BinaryOperatorMatch? _matchBinaryOperator(String buffer, int position) {
+  final start = _skipLuaTrivia(buffer, position);
+  if (start >= buffer.length) {
+    return null;
+  }
+
+  _BinaryOperatorMatch? match(
+    String lexeme,
+    int precedence, {
+    bool rightAssociative = false,
+    bool identifierBoundary = false,
+  }) {
+    final rawEnd = start + lexeme.length;
+    if (!_matchesLexeme(buffer, start, lexeme)) {
+      return null;
+    }
+    if (identifierBoundary &&
+        rawEnd < buffer.length &&
+        _isIdentifierContinueCodeUnit(buffer.codeUnitAt(rawEnd))) {
+      return null;
+    }
+    return _BinaryOperatorMatch(
+      lexeme: lexeme,
+      offset: start,
+      end: _skipLuaTrivia(buffer, rawEnd),
+      precedence: precedence,
+      rightAssociative: rightAssociative,
+    );
+  }
+
+  switch (buffer.codeUnitAt(start)) {
+    case 0x6F: // o
+      return match('or', 1, identifierBoundary: true);
+    case 0x61: // a
+      return match('and', 2, identifierBoundary: true);
+    case 0x3C: // <
+      return match('<<', 7) ?? match('<=', 3) ?? match('<', 3);
+    case 0x3E: // >
+      return match('>>', 7) ?? match('>=', 3) ?? match('>', 3);
+    case 0x3D: // =
+      return match('==', 3);
+    case 0x7E: // ~
+      return match('~=', 3) ?? match('~', 5);
+    case 0x7C: // |
+      return match('|', 4);
+    case 0x26: // &
+      return match('&', 6);
+    case 0x2E: // .
+      return match('..', 8, rightAssociative: true);
+    case 0x2B: // +
+      return match('+', 9);
+    case 0x2D: // -
+      return match('-', 9);
+    case 0x2A: // *
+      return match('*', 10);
+    case 0x2F: // /
+      return match('//', 10) ?? match('/', 10);
+    case 0x25: // %
+      return match('%', 10);
+  }
+  return null;
+}
+
+bool _matchesLexeme(String buffer, int position, String lexeme) {
+  final end = position + lexeme.length;
+  if (end > buffer.length) {
+    return false;
+  }
+  for (var i = 0; i < lexeme.length; i++) {
+    if (buffer.codeUnitAt(position + i) != lexeme.codeUnitAt(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool _matchesKeywordLexeme(String buffer, int position, String lexeme) {
+  final end = position + lexeme.length;
+  return _matchesLexeme(buffer, position, lexeme) &&
+      (end >= buffer.length ||
+          !_isIdentifierContinueCodeUnit(buffer.codeUnitAt(end)));
+}
+
+bool _startsLongBracket(String buffer, int position) {
+  if (position >= buffer.length || buffer.codeUnitAt(position) != 0x5B) {
+    return false;
+  }
+
+  var current = position + 1;
+  while (current < buffer.length && buffer.codeUnitAt(current) == 0x3D) {
+    current++;
+  }
+  return current < buffer.length && buffer.codeUnitAt(current) == 0x5B;
+}
+
+bool _isDigitCodeUnit(int codeUnit) => codeUnit >= 0x30 && codeUnit <= 0x39;
+
+class _TokenParser extends Parser<String> {
+  _TokenParser(this.lexeme, {required this.needsIdentifierBoundary});
+
+  final String lexeme;
+  final bool needsIdentifierBoundary;
+
+  @override
+  Result<String> parseOn(Context context) {
+    final start = _skipLuaTrivia(context.buffer, context.position);
+    final end = _matchEnd(context.buffer, start);
+    if (end < 0) {
+      return context.failure('"$lexeme" expected', start);
+    }
+    return context.success(lexeme, _skipLuaTrivia(context.buffer, end));
+  }
+
+  @override
+  int fastParseOn(String buffer, int position) {
+    final start = _skipLuaTrivia(buffer, position);
+    final end = _matchEnd(buffer, start);
+    return end < 0 ? -1 : _skipLuaTrivia(buffer, end);
+  }
+
+  int _matchEnd(String buffer, int start) {
+    final end = start + lexeme.length;
+    if (end > buffer.length) {
+      return -1;
+    }
+    for (var i = 0; i < lexeme.length; i++) {
+      if (buffer.codeUnitAt(start + i) != lexeme.codeUnitAt(i)) {
+        return -1;
+      }
+    }
+    if (needsIdentifierBoundary &&
+        end < buffer.length &&
+        _isIdentifierContinueCodeUnit(buffer.codeUnitAt(end))) {
+      return -1;
+    }
+    return end;
+  }
+
+  @override
+  _TokenParser copy() =>
+      _TokenParser(lexeme, needsIdentifierBoundary: needsIdentifierBoundary);
+
+  @override
+  bool hasEqualProperties(_TokenParser other) =>
+      super.hasEqualProperties(other) &&
+      lexeme == other.lexeme &&
+      needsIdentifierBoundary == other.needsIdentifierBoundary;
+
+  @override
+  String toString() => '"$lexeme" expected';
+}
+
+class _TriviaParser extends Parser<void> {
+  _TriviaParser();
+
+  @override
+  Result<void> parseOn(Context context) {
+    final current = _skipLuaTrivia(context.buffer, context.position);
+    if (current == context.position) {
+      return context.failure('whitespace or comment expected');
+    }
+    return context.success(null, current);
+  }
+
+  @override
+  int fastParseOn(String buffer, int position) {
+    final current = _skipLuaTrivia(buffer, position);
+    return current == position ? -1 : current;
+  }
+
+  @override
+  _TriviaParser copy() => _TriviaParser();
+}
+
+class _IdentifierParser extends Parser<Identifier> {
+  _IdentifierParser(this.definition);
+
+  final LuaGrammarDefinition definition;
+
+  @override
+  Result<Identifier> parseOn(Context context) {
+    final buffer = context.buffer;
+    final start = _skipLuaTrivia(buffer, context.position);
+    if (start >= buffer.length ||
+        !_isIdentifierStartCodeUnit(buffer.codeUnitAt(start))) {
+      return context.failure('identifier expected');
+    }
+
+    var current = start + 1;
+    while (current < buffer.length &&
+        _isIdentifierContinueCodeUnit(buffer.codeUnitAt(current))) {
+      current++;
+    }
+
+    final name = buffer.substring(start, current);
+    if (LuaGrammarDefinition._keywords.contains(name)) {
+      return context.failure('unexpected "$name"', start);
+    }
+
+    final id = Identifier(name);
+    id.setSpan(definition._sourceFile.span(start, current));
+    final end = _skipLuaTrivia(buffer, current);
+    return context.success(id, end);
+  }
+
+  @override
+  _IdentifierParser copy() => _IdentifierParser(definition);
+}
+
+int _skipLuaTrivia(String buffer, int position) {
+  var current = position;
+  while (current < buffer.length) {
+    final codeUnit = buffer.codeUnitAt(current);
+    if (_isLuaWhitespaceCodeUnit(codeUnit)) {
+      current++;
+      continue;
+    }
+
+    if (!_startsLineComment(buffer, current)) {
+      break;
+    }
+
+    final longCommentEnd = _scanLongCommentEnd(buffer, current + 2);
+    if (longCommentEnd != null) {
+      current = longCommentEnd;
+      continue;
+    }
+
+    current = _scanLineCommentEnd(buffer, current + 2);
+  }
+  return current;
+}
+
+bool _isLuaWhitespaceCodeUnit(int codeUnit) =>
+    codeUnit == 0x20 ||
+    codeUnit == 0x09 ||
+    codeUnit == 0x0A ||
+    codeUnit == 0x0B ||
+    codeUnit == 0x0C ||
+    codeUnit == 0x0D;
+
+bool _startsLineComment(String buffer, int position) =>
+    position + 1 < buffer.length &&
+    buffer.codeUnitAt(position) == 0x2D &&
+    buffer.codeUnitAt(position + 1) == 0x2D;
+
+int _scanLineCommentEnd(String buffer, int position) {
+  var current = position;
+  while (current < buffer.length) {
+    final codeUnit = buffer.codeUnitAt(current);
+    current++;
+    if (codeUnit == 0x0A || codeUnit == 0x0D) {
+      if (current < buffer.length) {
+        final next = buffer.codeUnitAt(current);
+        if ((codeUnit == 0x0A && next == 0x0D) ||
+            (codeUnit == 0x0D && next == 0x0A)) {
+          current++;
+        }
+      }
+      break;
+    }
+  }
+  return current;
+}
+
+int? _scanLongCommentEnd(String buffer, int position) {
+  if (position >= buffer.length || buffer.codeUnitAt(position) != 0x5B) {
+    return null;
+  }
+
+  var current = position + 1;
+  while (current < buffer.length && buffer.codeUnitAt(current) == 0x3D) {
+    current++;
+  }
+
+  if (current >= buffer.length || buffer.codeUnitAt(current) != 0x5B) {
+    return null;
+  }
+
+  final eqCount = current - position - 1;
+  final contentStart = current + 1;
+  final closing = ']${'=' * eqCount}]';
+  final closeIndex = buffer.indexOf(closing, contentStart);
+  if (closeIndex == -1) {
+    throw ParserException(
+      Failure(buffer, position - 2, "unfinished comment near '<eof>'"),
+    );
+  }
+  return closeIndex + closing.length;
+}
+
 class _LongBracketParser extends Parser<String> {
   _LongBracketParser();
 
@@ -1457,49 +2301,6 @@ class _LongBracketParser extends Parser<String> {
 
   @override
   _LongBracketParser copy() => _LongBracketParser();
-}
-
-class _LongCommentBracketParser extends Parser<String> {
-  _LongCommentBracketParser();
-
-  @override
-  Result<String> parseOn(Context context) {
-    final buffer = context.buffer;
-    final start = context.position;
-    if (start >= buffer.length || buffer.codeUnitAt(start) != 0x5B /* '[' */ ) {
-      return context.failure('long comment expected');
-    }
-    var idx = start + 1;
-    while (idx < buffer.length && buffer.codeUnitAt(idx) == 0x3D /* '=' */ ) {
-      idx++;
-    }
-    if (idx >= buffer.length || buffer.codeUnitAt(idx) != 0x5B) {
-      return context.failure('long comment start delimiter not found');
-    }
-    final eqCount = idx - start - 1;
-    final contentStart = idx + 1;
-    final closing = ']${'=' * eqCount}]';
-    final closeIdx = buffer.indexOf(closing, contentStart);
-    if (closeIdx == -1) {
-      // Unfinished long comment: surface a Lua-style error message.
-      // We can't use _createPositionedException here as we're outside the LuaGrammarDefinition class
-      throw ParserException(
-        Failure(buffer, context.position, "unfinished comment near '<eof>'"),
-      );
-    }
-    // Skip the content, return success at the end of the comment
-    return context.success('', closeIdx + closing.length);
-  }
-
-  @override
-  int fastParseOn(String buffer, int position) {
-    final ctx = Context(buffer, position);
-    final res = parseOn(ctx);
-    return res is Failure ? -1 : res.position;
-  }
-
-  @override
-  _LongCommentBracketParser copy() => _LongCommentBracketParser();
 }
 
 /// Parse [source] into an [AST] using the **new PetitParser** implementation.
@@ -1608,6 +2409,15 @@ bool _isIdentifierStartCodeUnit(int codeUnit) =>
 bool _isIdentifierContinueCodeUnit(int codeUnit) =>
     _isIdentifierStartCodeUnit(codeUnit) ||
     (codeUnit >= 0x30 && codeUnit <= 0x39);
+
+int _scanIdentifierEnd(String buffer, int start) {
+  var current = start + 1;
+  while (current < buffer.length &&
+      _isIdentifierContinueCodeUnit(buffer.codeUnitAt(current))) {
+    current++;
+  }
+  return current;
+}
 
 int _skipSyntaxTrivia(String source, int index) {
   var current = index;

--- a/pkgs/lualike/lib/src/parsers/lua.dart
+++ b/pkgs/lualike/lib/src/parsers/lua.dart
@@ -148,15 +148,7 @@ class LuaGrammarDefinition extends GrammarDefinition {
     );
   }
 
-  Parser _span(Parser inner) {
-    return (position() & inner & position()).map((vals) {
-      final start = vals[0] as int;
-      final node = vals[1] as AstNode;
-      final end = vals[2] as int;
-      node.setSpan(_sourceFile.span(start, end));
-      return node;
-    });
-  }
+  Parser _span(Parser inner) => _SpanParser(this, inner);
 
   Parser _identifier() => _IdentifierParser(this);
 
@@ -1072,6 +1064,40 @@ class LuaGrammarDefinition extends GrammarDefinition {
   T _annotate<T extends AstNode>(T node, int start, int end) {
     node.setSpan(_sourceFile.span(start, end));
     return node;
+  }
+}
+
+class _SpanParser extends Parser<AstNode> {
+  _SpanParser(this.definition, this.inner);
+
+  final LuaGrammarDefinition definition;
+  Parser inner;
+
+  @override
+  Result<AstNode> parseOn(Context context) {
+    final start = context.position;
+    final result = inner.parseOn(context);
+    if (result is Failure) {
+      return result;
+    }
+
+    final node = result.value as AstNode;
+    node.setSpan(definition._sourceFile.span(start, result.position));
+    return context.success(node, result.position);
+  }
+
+  @override
+  _SpanParser copy() => _SpanParser(definition, inner);
+
+  @override
+  List<Parser> get children => [inner];
+
+  @override
+  void replace(Parser source, Parser target) {
+    super.replace(source, target);
+    if (inner == source) {
+      inner = target;
+    }
   }
 }
 

--- a/pkgs/lualike/lib/src/parsers/lua.dart
+++ b/pkgs/lualike/lib/src/parsers/lua.dart
@@ -565,41 +565,12 @@ class LuaGrammarDefinition extends GrammarDefinition {
       _FieldParser(expression: ref0(_expression), identifier: _identifier());
 
   // prefixexp ::= var | functioncall | '(' exp ')'
-  Parser _prefixExp() {
-    final base = (_identifier() | ref0(_groupedExpression));
-
-    final suffix = ref0(_suffix).star();
-
-    return (base & suffix).map((values) {
-      AstNode expr = values[0] as AstNode;
-      final sufs = (values[1] as List).cast<_PrefixSuffix>();
-      for (final s in sufs) {
-        if (s is _IndexSuffix) {
-          final access = TableIndexAccess(expr, s.expression);
-          access.setSpan(expr.span ?? _sourceFile.span(0, 0));
-          expr = access;
-        } else if (s is _FieldSuffix) {
-          final access = TableFieldAccess(expr, s.identifier);
-          access.setSpan(expr.span ?? _sourceFile.span(0, 0));
-          expr = access;
-        } else if (s is _CallSuffix) {
-          final call = FunctionCall(expr, s.args);
-          call.setSpan(expr.span ?? _sourceFile.span(0, 0));
-          expr = call;
-        } else if (s is _MethodSuffix) {
-          final mcall = MethodCall(
-            expr,
-            s.identifier,
-            s.args,
-            implicitSelf: true,
-          );
-          mcall.setSpan(expr.span ?? _sourceFile.span(0, 0));
-          expr = mcall;
-        }
-      }
-      return expr;
-    });
-  }
+  Parser _prefixExp() => _PrefixExpressionParser(
+    definition: this,
+    identifier: _identifier(),
+    groupedExpression: ref0(_groupedExpression),
+    suffix: ref0(_suffix),
+  );
 
   Parser _suffix() => _SuffixParser(
     expression: ref0(_expression),
@@ -1597,6 +1568,111 @@ final class _MethodSuffix extends _PrefixSuffix {
 
   final Identifier identifier;
   final List<AstNode> args;
+}
+
+class _PrefixExpressionParser extends Parser<AstNode> {
+  _PrefixExpressionParser({
+    required this.definition,
+    required this.identifier,
+    required this.groupedExpression,
+    required this.suffix,
+  });
+
+  final LuaGrammarDefinition definition;
+  Parser identifier;
+  Parser groupedExpression;
+  Parser suffix;
+
+  @override
+  Result<AstNode> parseOn(Context context) {
+    final buffer = context.buffer;
+    final start = _skipLuaTrivia(buffer, context.position);
+    if (start >= buffer.length) {
+      return context.failure('prefix expression expected', start);
+    }
+
+    Result baseResult;
+    if (buffer.codeUnitAt(start) == 0x28) {
+      baseResult = groupedExpression.parseOn(Context(buffer, start));
+    } else if (_isIdentifierStartCodeUnit(buffer.codeUnitAt(start))) {
+      baseResult = identifier.parseOn(Context(buffer, start));
+    } else {
+      return context.failure('prefix expression expected', start);
+    }
+    if (baseResult is Failure) {
+      return baseResult;
+    }
+
+    var expression = baseResult.value as AstNode;
+    var current = baseResult.position;
+    while (true) {
+      final suffixResult = suffix.parseOn(Context(buffer, current));
+      if (suffixResult is Failure) {
+        break;
+      }
+      expression = _applySuffix(
+        expression,
+        suffixResult.value as _PrefixSuffix,
+      );
+      current = suffixResult.position;
+    }
+
+    return context.success(expression, current);
+  }
+
+  AstNode _applySuffix(AstNode expression, _PrefixSuffix suffix) {
+    if (suffix is _IndexSuffix) {
+      final access = TableIndexAccess(expression, suffix.expression);
+      access.setSpan(expression.span ?? definition._sourceFile.span(0, 0));
+      return access;
+    }
+    if (suffix is _FieldSuffix) {
+      final access = TableFieldAccess(expression, suffix.identifier);
+      access.setSpan(expression.span ?? definition._sourceFile.span(0, 0));
+      return access;
+    }
+    if (suffix is _CallSuffix) {
+      final call = FunctionCall(expression, suffix.args);
+      call.setSpan(expression.span ?? definition._sourceFile.span(0, 0));
+      return call;
+    }
+    if (suffix is _MethodSuffix) {
+      final call = MethodCall(
+        expression,
+        suffix.identifier,
+        suffix.args,
+        implicitSelf: true,
+      );
+      call.setSpan(expression.span ?? definition._sourceFile.span(0, 0));
+      return call;
+    }
+    return expression;
+  }
+
+  @override
+  _PrefixExpressionParser copy() => _PrefixExpressionParser(
+    definition: definition,
+    identifier: identifier,
+    groupedExpression: groupedExpression,
+    suffix: suffix,
+  );
+
+  @override
+  List<Parser> get children => [identifier, groupedExpression, suffix];
+
+  @override
+  void replace(Parser source, Parser target) {
+    super.replace(source, target);
+    if (identifier == source) {
+      identifier = target;
+    }
+    if (groupedExpression == source) {
+      groupedExpression = target;
+    }
+    if (suffix == source) {
+      suffix = target;
+    }
+  }
 }
 
 class _SuffixParser extends Parser<_PrefixSuffix> {

--- a/pkgs/lualike/lib/src/parsers/lua.dart
+++ b/pkgs/lualike/lib/src/parsers/lua.dart
@@ -155,49 +155,7 @@ class LuaGrammarDefinition extends GrammarDefinition {
   // Matches Lua numeric literals:
   //   • Decimal:  123   1.5   .5   1e3   1.5e-2
   //   • Hex:      0xFF  0X1.8p+4  0x1p-1
-  Parser _numberLiteral() {
-    // ---------- helpers ----------
-    final hexDigit = pattern('0-9A-Fa-f');
-    final decDigit = digit();
-
-    // Hex prefix 0x / 0X
-    final hexPrefix = string('0') & pattern('xX');
-
-    // Hex exponent P / p with optional sign and digits
-    final hexExp = pattern('pP') & pattern('+-').optional() & decDigit.plus();
-
-    // Hexadecimal numeral: 0x[hexdigits](.[hexdigits])?(_hexExp)?
-    final hexInt = hexPrefix & hexDigit.plus();
-    final hexFrac = hexPrefix & hexDigit.star() & char('.') & hexDigit.plus();
-    final hexNumber = (hexFrac | hexInt) & hexExp.optional();
-
-    // Decimal parts
-    final decInt = decDigit.plus();
-    final decFrac1 = decDigit.plus() & char('.') & decDigit.star();
-    final decFrac2 = char('.') & decDigit.plus();
-    final decExp = pattern('eE') & pattern('+-').optional() & decDigit.plus();
-
-    final decimalUnsigned = ((decFrac1 | decFrac2 | decInt) & decExp.optional())
-        .flatten();
-
-    // Lua numeric literals do NOT include a leading sign; signs are handled
-    // by the separate unary operator. Keep the literal unsigned.
-    final decimalNumber = decimalUnsigned;
-
-    final hexNumberFlatten = hexNumber.flatten();
-
-    return position()
-        .seq((hexNumberFlatten | decimalNumber))
-        .seq(position())
-        .trim(ref0(_whiteSpaceAndComments))
-        .map((vals) {
-          final start = vals[0] as int;
-          final lexeme = vals[1] as String;
-          final end = vals[2] as int;
-          final node = NumberLiteral(LuaNumberParser.parse(lexeme));
-          return _annotate(node, start, end);
-        });
-  }
+  Parser _numberLiteral() => _NumberLiteralParser(this);
 
   // ---------- Grammar rules -------------------------------------------------
   @override
@@ -1186,6 +1144,37 @@ class _StringLiteralParser extends Parser<StringLiteral> {
   _StringLiteralParser copy() => _StringLiteralParser(definition);
 }
 
+class _NumberLiteralParser extends Parser<NumberLiteral> {
+  _NumberLiteralParser(this.definition);
+
+  final LuaGrammarDefinition definition;
+
+  @override
+  Result<NumberLiteral> parseOn(Context context) {
+    final buffer = context.buffer;
+    final start = _skipLuaTrivia(buffer, context.position);
+    final rawEnd = _scanLuaNumberEnd(buffer, start);
+    if (rawEnd < 0) {
+      return context.failure('number expected', start);
+    }
+
+    final lexeme = buffer.substring(start, rawEnd);
+    final node = NumberLiteral(LuaNumberParser.parse(lexeme));
+    node.setSpan(definition._sourceFile.span(start, rawEnd));
+    return context.success(node, _skipLuaTrivia(buffer, rawEnd));
+  }
+
+  @override
+  int fastParseOn(String buffer, int position) {
+    final start = _skipLuaTrivia(buffer, position);
+    final rawEnd = _scanLuaNumberEnd(buffer, start);
+    return rawEnd < 0 ? -1 : _skipLuaTrivia(buffer, rawEnd);
+  }
+
+  @override
+  _NumberLiteralParser copy() => _NumberLiteralParser(definition);
+}
+
 class _ExpressionListParser extends Parser<List<AstNode>> {
   _ExpressionListParser(this.expression, this.comma);
 
@@ -2018,6 +2007,121 @@ bool _startsLongBracket(String buffer, int position) {
 }
 
 bool _isDigitCodeUnit(int codeUnit) => codeUnit >= 0x30 && codeUnit <= 0x39;
+
+bool _isHexDigitCodeUnit(int codeUnit) =>
+    (codeUnit >= 0x30 && codeUnit <= 0x39) ||
+    (codeUnit >= 0x41 && codeUnit <= 0x46) ||
+    (codeUnit >= 0x61 && codeUnit <= 0x66);
+
+int _scanLuaNumberEnd(String buffer, int start) {
+  if (start >= buffer.length) {
+    return -1;
+  }
+
+  final first = buffer.codeUnitAt(start);
+  if (first == 0x2E) {
+    return _scanDecimalFractionEnd(buffer, start);
+  }
+  if (!_isDigitCodeUnit(first)) {
+    return -1;
+  }
+  if (first == 0x30 &&
+      start + 1 < buffer.length &&
+      _isHexPrefixCodeUnit(buffer.codeUnitAt(start + 1))) {
+    return _scanHexNumberEnd(buffer, start);
+  }
+  return _scanDecimalNumberEnd(buffer, start);
+}
+
+bool _isHexPrefixCodeUnit(int codeUnit) => codeUnit == 0x78 || codeUnit == 0x58;
+
+int _scanDecimalNumberEnd(String buffer, int start) {
+  var current = _scanDecimalDigits(buffer, start);
+  if (current < buffer.length && buffer.codeUnitAt(current) == 0x2E) {
+    current = _scanDecimalDigits(buffer, current + 1);
+  }
+  return _scanExponentEnd(buffer, current, lower: 0x65, upper: 0x45) ?? current;
+}
+
+int _scanDecimalFractionEnd(String buffer, int start) {
+  final digitStart = start + 1;
+  final digitEnd = _scanDecimalDigits(buffer, digitStart);
+  if (digitEnd == digitStart) {
+    return -1;
+  }
+  return _scanExponentEnd(buffer, digitEnd, lower: 0x65, upper: 0x45) ??
+      digitEnd;
+}
+
+int _scanHexNumberEnd(String buffer, int start) {
+  final bodyStart = start + 2;
+  final integerEnd = _scanHexDigits(buffer, bodyStart);
+  late final int current;
+
+  if (integerEnd < buffer.length && buffer.codeUnitAt(integerEnd) == 0x2E) {
+    final fractionStart = integerEnd + 1;
+    final fractionEnd = _scanHexDigits(buffer, fractionStart);
+    if (fractionEnd > fractionStart) {
+      current = fractionEnd;
+    } else if (integerEnd > bodyStart) {
+      current = integerEnd;
+    } else {
+      return -1;
+    }
+  } else {
+    if (integerEnd == bodyStart) {
+      return -1;
+    }
+    current = integerEnd;
+  }
+
+  return _scanExponentEnd(buffer, current, lower: 0x70, upper: 0x50) ?? current;
+}
+
+int _scanDecimalDigits(String buffer, int position) {
+  var current = position;
+  while (current < buffer.length &&
+      _isDigitCodeUnit(buffer.codeUnitAt(current))) {
+    current++;
+  }
+  return current;
+}
+
+int _scanHexDigits(String buffer, int position) {
+  var current = position;
+  while (current < buffer.length &&
+      _isHexDigitCodeUnit(buffer.codeUnitAt(current))) {
+    current++;
+  }
+  return current;
+}
+
+int? _scanExponentEnd(
+  String buffer,
+  int position, {
+  required int lower,
+  required int upper,
+}) {
+  if (position >= buffer.length) {
+    return null;
+  }
+  final marker = buffer.codeUnitAt(position);
+  if (marker != lower && marker != upper) {
+    return null;
+  }
+
+  var current = position + 1;
+  if (current < buffer.length) {
+    final sign = buffer.codeUnitAt(current);
+    if (sign == 0x2B || sign == 0x2D) {
+      current++;
+    }
+  }
+
+  final digitStart = current;
+  current = _scanDecimalDigits(buffer, current);
+  return current == digitStart ? null : current;
+}
 
 class _TokenParser extends Parser<String> {
   _TokenParser(this.lexeme, {required this.needsIdentifierBoundary})

--- a/pkgs/lualike/lib/src/parsers/lua.dart
+++ b/pkgs/lualike/lib/src/parsers/lua.dart
@@ -850,31 +850,11 @@ class LuaGrammarDefinition extends GrammarDefinition {
 
   // Parses a chain of '^' operators with right associativity. The right-hand
   // operand is a full unary expression, matching Lua’s grammar.
-  Parser _powerExpression() {
-    final tail = (_binaryOperatorToken(_token('^')) & ref0(_unaryExpression))
-        .star();
-
-    return (ref0(_primaryExpression) & tail).map((vals) {
-      AstNode node = vals[0] as AstNode;
-      final rest = vals[1] as List;
-
-      // Build right-associative: process from right to left.
-      for (var i = rest.length - 1; i >= 0; i--) {
-        final op = rest[i][0];
-        final rhs = rest[i][1] as AstNode;
-        node = _makeBinaryExpression(node, op, rhs);
-      }
-      return node;
-    });
-  }
-
-  Parser _binaryOperatorToken(Parser tokenParser) {
-    return (position() & tokenParser).map((vals) {
-      final offset = vals[0] as int;
-      final op = vals[1] as String;
-      return (op: op, offset: offset);
-    });
-  }
+  Parser _powerExpression() => _PowerExpressionParser(
+    definition: this,
+    primaryExpression: ref0(_primaryExpression),
+    unaryExpression: ref0(_unaryExpression),
+  );
 
   int? _binaryOperatorLine(dynamic opSpec) => switch (opSpec) {
     ({String op, int line}) value => value.line,
@@ -1746,6 +1726,85 @@ class _PrimaryExpressionParser extends Parser<AstNode> {
     }
     if (tableConstructor == source) {
       tableConstructor = target;
+    }
+  }
+}
+
+class _PowerExpressionParser extends Parser<AstNode> {
+  _PowerExpressionParser({
+    required this.definition,
+    required this.primaryExpression,
+    required this.unaryExpression,
+  });
+
+  final LuaGrammarDefinition definition;
+  Parser primaryExpression;
+  Parser unaryExpression;
+
+  @override
+  Result<AstNode> parseOn(Context context) {
+    final firstResult = primaryExpression.parseOn(context);
+    if (firstResult is Failure) {
+      return firstResult;
+    }
+
+    final buffer = context.buffer;
+    var node = firstResult.value as AstNode;
+    var current = firstResult.position;
+    List<({int offset, AstNode rhs})>? tails;
+
+    while (true) {
+      final operatorStart = _skipLuaTrivia(buffer, current);
+      if (operatorStart >= buffer.length ||
+          buffer.codeUnitAt(operatorStart) != 0x5E) {
+        break;
+      }
+
+      final rhsResult = unaryExpression.parseOn(
+        Context(buffer, _skipLuaTrivia(buffer, operatorStart + 1)),
+      );
+      if (rhsResult is Failure) {
+        return rhsResult;
+      }
+      (tails ??= <({int offset, AstNode rhs})>[]).add((
+        offset: operatorStart,
+        rhs: rhsResult.value as AstNode,
+      ));
+      current = rhsResult.position;
+    }
+
+    final parsedTails = tails;
+    if (parsedTails != null) {
+      for (var i = parsedTails.length - 1; i >= 0; i--) {
+        final tail = parsedTails[i];
+        node = definition._makeBinaryExpression(node, (
+          op: '^',
+          offset: tail.offset,
+        ), tail.rhs);
+      }
+    }
+
+    return context.success(node, current);
+  }
+
+  @override
+  _PowerExpressionParser copy() => _PowerExpressionParser(
+    definition: definition,
+    primaryExpression: primaryExpression,
+    unaryExpression: unaryExpression,
+  );
+
+  @override
+  List<Parser> get children => [primaryExpression, unaryExpression];
+
+  @override
+  void replace(Parser source, Parser target) {
+    super.replace(source, target);
+    if (primaryExpression == source) {
+      primaryExpression = target;
+    }
+    if (unaryExpression == source) {
+      unaryExpression = target;
     }
   }
 }

--- a/pkgs/lualike/lib/src/parsers/lua.dart
+++ b/pkgs/lualike/lib/src/parsers/lua.dart
@@ -2219,14 +2219,17 @@ class _ParameterListParser extends Parser<Map<String, Object?>> {
 
 int _skipLuaTrivia(String buffer, int position) {
   var current = position;
-  while (current < buffer.length) {
+  final length = buffer.length;
+  while (current < length) {
     final codeUnit = buffer.codeUnitAt(current);
     if (_isLuaWhitespaceCodeUnit(codeUnit)) {
       current++;
       continue;
     }
 
-    if (!_startsLineComment(buffer, current)) {
+    if (codeUnit != 0x2D ||
+        current + 1 >= length ||
+        buffer.codeUnitAt(current + 1) != 0x2D) {
       break;
     }
 
@@ -2248,11 +2251,6 @@ bool _isLuaWhitespaceCodeUnit(int codeUnit) =>
     codeUnit == 0x0B ||
     codeUnit == 0x0C ||
     codeUnit == 0x0D;
-
-bool _startsLineComment(String buffer, int position) =>
-    position + 1 < buffer.length &&
-    buffer.codeUnitAt(position) == 0x2D &&
-    buffer.codeUnitAt(position + 1) == 0x2D;
 
 int _scanLineCommentEnd(String buffer, int position) {
   var current = position;

--- a/pkgs/lualike/lib/src/parsers/lua.dart
+++ b/pkgs/lualike/lib/src/parsers/lua.dart
@@ -1606,6 +1606,11 @@ class _PrefixExpressionParser extends Parser<AstNode> {
     var expression = baseResult.value as AstNode;
     var current = baseResult.position;
     while (true) {
+      final suffixStart = _skipLuaTrivia(buffer, current);
+      if (!_couldStartSuffix(buffer, suffixStart)) {
+        break;
+      }
+
       final suffixResult = suffix.parseOn(Context(buffer, current));
       if (suffixResult is Failure) {
         break;
@@ -1618,6 +1623,24 @@ class _PrefixExpressionParser extends Parser<AstNode> {
     }
 
     return context.success(expression, current);
+  }
+
+  bool _couldStartSuffix(String buffer, int start) {
+    if (start >= buffer.length) {
+      return false;
+    }
+
+    switch (buffer.codeUnitAt(start)) {
+      case 0x5B: // [
+      case 0x2E: // .
+      case 0x3A: // :
+      case 0x28: // (
+      case 0x7B: // {
+      case 0x22: // "
+      case 0x27: // '
+        return true;
+    }
+    return false;
   }
 
   AstNode _applySuffix(AstNode expression, _PrefixSuffix suffix) {

--- a/pkgs/lualike/lib/src/parsers/lua.dart
+++ b/pkgs/lualike/lib/src/parsers/lua.dart
@@ -2020,17 +2020,19 @@ bool _startsLongBracket(String buffer, int position) {
 bool _isDigitCodeUnit(int codeUnit) => codeUnit >= 0x30 && codeUnit <= 0x39;
 
 class _TokenParser extends Parser<String> {
-  _TokenParser(this.lexeme, {required this.needsIdentifierBoundary});
+  _TokenParser(this.lexeme, {required this.needsIdentifierBoundary})
+    : failureMessage = '"$lexeme" expected';
 
   final String lexeme;
   final bool needsIdentifierBoundary;
+  final String failureMessage;
 
   @override
   Result<String> parseOn(Context context) {
     final start = _skipLuaTrivia(context.buffer, context.position);
     final end = _matchEnd(context.buffer, start);
     if (end < 0) {
-      return context.failure('"$lexeme" expected', start);
+      return context.failure(failureMessage, start);
     }
     return context.success(lexeme, _skipLuaTrivia(context.buffer, end));
   }
@@ -2071,7 +2073,7 @@ class _TokenParser extends Parser<String> {
       needsIdentifierBoundary == other.needsIdentifierBoundary;
 
   @override
-  String toString() => '"$lexeme" expected';
+  String toString() => failureMessage;
 }
 
 class _TriviaParser extends Parser<void> {

--- a/pkgs/lualike/lib/src/parsers/lua.dart
+++ b/pkgs/lualike/lib/src/parsers/lua.dart
@@ -200,36 +200,79 @@ class LuaGrammarDefinition extends GrammarDefinition {
           });
 
   // stat ::= empty ';' or assignment or expression statement
-  Parser _stat() =>
-      _token(';').map((_) => null) |
-      ref0(_globalStat) |
-      ref0(_localFunctionDefStat) |
-      ref0(_functionDefStat) |
-      ref0(_localDeclaration) |
-      ref0(_forNumericStat) |
-      ref0(_forGenericStat) |
-      ref0(_doBlockStat) |
-      ref0(_whileStat) |
-      ref0(_repeatStat) |
-      ref0(_ifStat) |
-      ref0(_breakStat) |
-      ref0(_labelStat) |
-      ref0(_gotoStat) |
-      ref0(_returnlessExprStatement) |
-      ref0(_assignment) |
-      // Error case: Detect bare string literals and report appropriate error
-      _stringLiteral().map((literal) {
-        final errorText =
-            literal.span?.text ??
-            (literal.isLongString
-                ? '[[${literal.value}]]'
-                : '"${literal.value}"');
+  Parser _stat() {
+    final semicolon = _token(';').map((_) => null);
+    final globalStat = ref0(_globalStat);
+    final localFunctionDefStat = ref0(_localFunctionDefStat);
+    final functionDefStat = ref0(_functionDefStat);
+    final localDeclaration = ref0(_localDeclaration);
+    final forNumericStat = ref0(_forNumericStat);
+    final forGenericStat = ref0(_forGenericStat);
+    final doBlockStat = ref0(_doBlockStat);
+    final whileStat = ref0(_whileStat);
+    final repeatStat = ref0(_repeatStat);
+    final ifStat = ref0(_ifStat);
+    final breakStat = ref0(_breakStat);
+    final labelStat = ref0(_labelStat);
+    final gotoStat = ref0(_gotoStat);
+    final returnlessExprStatement = ref0(_returnlessExprStatement);
+    final assignment = ref0(_assignment);
+    final stringStatementError = _stringLiteral().map(
+      (literal) => _throwBareStringStatement(literal as StringLiteral),
+    );
 
-        throw _createPositionedException(
-          literal,
-          'unexpected symbol near \'$errorText\'',
-        );
-      });
+    final fallback =
+        semicolon |
+        globalStat |
+        localFunctionDefStat |
+        functionDefStat |
+        localDeclaration |
+        forNumericStat |
+        forGenericStat |
+        doBlockStat |
+        whileStat |
+        repeatStat |
+        ifStat |
+        breakStat |
+        labelStat |
+        gotoStat |
+        returnlessExprStatement |
+        assignment |
+        stringStatementError;
+
+    return _StatementParser(
+      semicolon: semicolon,
+      globalStat: globalStat,
+      localFunctionDefStat: localFunctionDefStat,
+      functionDefStat: functionDefStat,
+      localDeclaration: localDeclaration,
+      forNumericStat: forNumericStat,
+      forGenericStat: forGenericStat,
+      doBlockStat: doBlockStat,
+      whileStat: whileStat,
+      repeatStat: repeatStat,
+      ifStat: ifStat,
+      breakStat: breakStat,
+      labelStat: labelStat,
+      gotoStat: gotoStat,
+      returnlessExprStatement: returnlessExprStatement,
+      assignment: assignment,
+      stringStatementError: stringStatementError,
+      fallback: fallback,
+    );
+  }
+
+  // Error case: Detect bare string literals and report appropriate error
+  Never _throwBareStringStatement(StringLiteral literal) {
+    final errorText =
+        literal.span?.text ??
+        (literal.isLongString ? '[[${literal.value}]]' : '"${literal.value}"');
+
+    throw _createPositionedException(
+      literal,
+      'unexpected symbol near \'$errorText\'',
+    );
+  }
 
   // retstat ::= return [explist] [';']
   Parser _retstat() => _span(
@@ -1002,6 +1045,204 @@ class LuaGrammarDefinition extends GrammarDefinition {
   T _annotate<T extends AstNode>(T node, int start, int end) {
     node.setSpan(_sourceFile.span(start, end));
     return node;
+  }
+}
+
+class _StatementParser extends Parser<dynamic> {
+  _StatementParser({
+    required this.semicolon,
+    required this.globalStat,
+    required this.localFunctionDefStat,
+    required this.functionDefStat,
+    required this.localDeclaration,
+    required this.forNumericStat,
+    required this.forGenericStat,
+    required this.doBlockStat,
+    required this.whileStat,
+    required this.repeatStat,
+    required this.ifStat,
+    required this.breakStat,
+    required this.labelStat,
+    required this.gotoStat,
+    required this.returnlessExprStatement,
+    required this.assignment,
+    required this.stringStatementError,
+    required this.fallback,
+  });
+
+  Parser semicolon;
+  Parser globalStat;
+  Parser localFunctionDefStat;
+  Parser functionDefStat;
+  Parser localDeclaration;
+  Parser forNumericStat;
+  Parser forGenericStat;
+  Parser doBlockStat;
+  Parser whileStat;
+  Parser repeatStat;
+  Parser ifStat;
+  Parser breakStat;
+  Parser labelStat;
+  Parser gotoStat;
+  Parser returnlessExprStatement;
+  Parser assignment;
+  Parser stringStatementError;
+  Parser fallback;
+
+  @override
+  Result parseOn(Context context) {
+    final buffer = context.buffer;
+    final start = _skipLuaTrivia(buffer, context.position);
+    if (start >= buffer.length) {
+      return fallback.parseOn(context);
+    }
+
+    switch (buffer.codeUnitAt(start)) {
+      case 0x3B: // ;
+        return semicolon.parseOn(context);
+      case 0x67: // g
+        if (_matchesKeywordLexeme(buffer, start, 'global')) {
+          final result = globalStat.parseOn(context);
+          return result is Failure ? _parseCallOrAssignment(context) : result;
+        }
+        if (_matchesKeywordLexeme(buffer, start, 'goto')) {
+          return gotoStat.parseOn(context);
+        }
+        break;
+      case 0x6C: // l
+        if (_matchesKeywordLexeme(buffer, start, 'local')) {
+          final functionResult = localFunctionDefStat.parseOn(context);
+          return functionResult is Failure
+              ? localDeclaration.parseOn(context)
+              : functionResult;
+        }
+        break;
+      case 0x66: // f
+        if (_matchesKeywordLexeme(buffer, start, 'function')) {
+          return functionDefStat.parseOn(context);
+        }
+        if (_matchesKeywordLexeme(buffer, start, 'for')) {
+          final numericResult = forNumericStat.parseOn(context);
+          return numericResult is Failure
+              ? forGenericStat.parseOn(context)
+              : numericResult;
+        }
+        break;
+      case 0x64: // d
+        if (_matchesKeywordLexeme(buffer, start, 'do')) {
+          return doBlockStat.parseOn(context);
+        }
+        break;
+      case 0x77: // w
+        if (_matchesKeywordLexeme(buffer, start, 'while')) {
+          return whileStat.parseOn(context);
+        }
+        break;
+      case 0x72: // r
+        if (_matchesKeywordLexeme(buffer, start, 'repeat')) {
+          return repeatStat.parseOn(context);
+        }
+        break;
+      case 0x69: // i
+        if (_matchesKeywordLexeme(buffer, start, 'if')) {
+          return ifStat.parseOn(context);
+        }
+        break;
+      case 0x62: // b
+        if (_matchesKeywordLexeme(buffer, start, 'break')) {
+          return breakStat.parseOn(context);
+        }
+        break;
+      case 0x3A: // :
+        return labelStat.parseOn(context);
+      case 0x22: // "
+      case 0x27: // '
+        return stringStatementError.parseOn(context);
+      case 0x5B: // [
+        if (_startsLongBracket(buffer, start)) {
+          return stringStatementError.parseOn(context);
+        }
+        break;
+    }
+
+    if (_isIdentifierStartCodeUnit(buffer.codeUnitAt(start)) ||
+        buffer.codeUnitAt(start) == 0x28) {
+      return _parseCallOrAssignment(context);
+    }
+
+    return fallback.parseOn(context);
+  }
+
+  Result _parseCallOrAssignment(Context context) {
+    final callResult = returnlessExprStatement.parseOn(context);
+    return callResult is Failure ? assignment.parseOn(context) : callResult;
+  }
+
+  @override
+  _StatementParser copy() => _StatementParser(
+    semicolon: semicolon,
+    globalStat: globalStat,
+    localFunctionDefStat: localFunctionDefStat,
+    functionDefStat: functionDefStat,
+    localDeclaration: localDeclaration,
+    forNumericStat: forNumericStat,
+    forGenericStat: forGenericStat,
+    doBlockStat: doBlockStat,
+    whileStat: whileStat,
+    repeatStat: repeatStat,
+    ifStat: ifStat,
+    breakStat: breakStat,
+    labelStat: labelStat,
+    gotoStat: gotoStat,
+    returnlessExprStatement: returnlessExprStatement,
+    assignment: assignment,
+    stringStatementError: stringStatementError,
+    fallback: fallback,
+  );
+
+  @override
+  List<Parser> get children => [
+    semicolon,
+    globalStat,
+    localFunctionDefStat,
+    functionDefStat,
+    localDeclaration,
+    forNumericStat,
+    forGenericStat,
+    doBlockStat,
+    whileStat,
+    repeatStat,
+    ifStat,
+    breakStat,
+    labelStat,
+    gotoStat,
+    returnlessExprStatement,
+    assignment,
+    stringStatementError,
+    fallback,
+  ];
+
+  @override
+  void replace(Parser source, Parser target) {
+    super.replace(source, target);
+    if (semicolon == source) semicolon = target;
+    if (globalStat == source) globalStat = target;
+    if (localFunctionDefStat == source) localFunctionDefStat = target;
+    if (functionDefStat == source) functionDefStat = target;
+    if (localDeclaration == source) localDeclaration = target;
+    if (forNumericStat == source) forNumericStat = target;
+    if (forGenericStat == source) forGenericStat = target;
+    if (doBlockStat == source) doBlockStat = target;
+    if (whileStat == source) whileStat = target;
+    if (repeatStat == source) repeatStat = target;
+    if (ifStat == source) ifStat = target;
+    if (breakStat == source) breakStat = target;
+    if (labelStat == source) labelStat = target;
+    if (gotoStat == source) gotoStat = target;
+    if (returnlessExprStatement == source) returnlessExprStatement = target;
+    if (assignment == source) assignment = target;
+    if (stringStatementError == source) stringStatementError = target;
+    if (fallback == source) fallback = target;
   }
 }
 

--- a/pkgs/lualike/lib/src/parsers/pattern.dart
+++ b/pkgs/lualike/lib/src/parsers/pattern.dart
@@ -67,6 +67,28 @@ Parser<String> _classFor(String letter) {
 
 Parser<String> _negate(Parser<String> p) => p.neg();
 
+bool _isAsciiLetter(int codeUnit) =>
+    (codeUnit >= 0x41 && codeUnit <= 0x5A) ||
+    (codeUnit >= 0x61 && codeUnit <= 0x7A);
+
+bool _isAsciiUpper(int codeUnit) => codeUnit >= 0x41 && codeUnit <= 0x5A;
+
+String _asciiLowerChar(int codeUnit) =>
+    String.fromCharCode(_isAsciiUpper(codeUnit) ? codeUnit + 0x20 : codeUnit);
+
+bool _isAsciiOneToNine(int codeUnit) => codeUnit >= 0x31 && codeUnit <= 0x39;
+
+bool _isRepetitionOperator(int codeUnit) {
+  switch (codeUnit) {
+    case 0x2A: // *
+    case 0x2B: // +
+    case 0x2D: // -
+    case 0x3F: // ?
+      return true;
+  }
+  return false;
+}
+
 /// Parser that matches a balanced pair like `%bxy` in Lua.
 class _BalancedParser extends Parser<String> {
   final String open;
@@ -274,9 +296,10 @@ Parser<String> _bracketClass(String spec, {required bool negate}) {
         throw FormatException('Malformed set: \$spec');
       }
       final letter = spec[index + 1];
-      if (RegExp(r'[a-zA-Z]').hasMatch(letter)) {
-        final base = _classFor(letter.toLowerCase());
-        final cls = letter == letter.toUpperCase() ? _negate(base) : base;
+      final letterCode = letter.codeUnitAt(0);
+      if (_isAsciiLetter(letterCode)) {
+        final base = _classFor(_asciiLowerChar(letterCode));
+        final cls = _isAsciiUpper(letterCode) ? _negate(base) : base;
         return (parser: cls, nextIndex: index + 2, literalCodeUnit: null);
       }
       return (
@@ -478,10 +501,14 @@ class LuaPatternCompiler {
     }
 
     if (_pos < _pattern.length) {
-      final rep = _pattern[_pos];
-      if ('*+-?'.contains(rep)) {
+      final repCode = _pattern.codeUnitAt(_pos);
+      if (_isRepetitionOperator(repCode)) {
         _pos++; // consume repetition operator
-        item = _applyRepetition(item, rep, stopOnRightParen);
+        item = _applyRepetition(
+          item,
+          String.fromCharCode(repCode),
+          stopOnRightParen,
+        );
       }
     }
     return item;
@@ -590,8 +617,9 @@ class LuaPatternCompiler {
     if (next == '0') {
       throw FormatException('invalid capture index %0');
     }
-    if ('123456789'.contains(next)) {
-      final index = int.parse(next) - 1;
+    final nextCode = next.codeUnitAt(0);
+    if (_isAsciiOneToNine(nextCode)) {
+      final index = nextCode - 0x31;
       if (index >= _captures.length || _openCaptures.contains(index)) {
         throw FormatException('invalid capture index %$next');
       }
@@ -622,10 +650,10 @@ class LuaPatternCompiler {
       _pos = _findBracketEndFrom(_pos) + 1;
       return _FrontierParser(set);
     }
-    if (RegExp(r'[a-zA-Z]').hasMatch(next)) {
+    if (_isAsciiLetter(nextCode)) {
       _pos++;
-      final base = _classFor(next.toLowerCase());
-      final parser = next == next.toUpperCase() ? _negate(base) : base;
+      final base = _classFor(_asciiLowerChar(nextCode));
+      final parser = _isAsciiUpper(nextCode) ? _negate(base) : base;
       return parser;
     }
     _pos++;
@@ -713,15 +741,27 @@ class LuaPattern {
     this._captures,
     this._positionCaptureIndexes,
     this._captureCount,
-  );
+  ) : _literalPattern = null;
 
-  final _LuaPatternParser _parser;
+  LuaPattern._literal(this._literalPattern)
+    : _parser = null,
+      _captures = const <String?>[],
+      _positionCaptureIndexes = const <int>{},
+      _captureCount = 0;
+
+  final _LuaPatternParser? _parser;
+  final String? _literalPattern;
   final List<String?> _captures;
   final Set<int> _positionCaptureIndexes;
   final int _captureCount;
 
   /// Compile [pattern] into a [LuaPattern].
   factory LuaPattern.compile(String pattern) {
+    final literalPattern = _plainLiteralPattern(pattern);
+    if (literalPattern != null) {
+      return LuaPattern._literal(literalPattern);
+    }
+
     final compiler = LuaPatternCompiler(pattern);
     final parser = compiler.compile() as _LuaPatternParser;
     return LuaPattern._(
@@ -734,8 +774,24 @@ class LuaPattern {
 
   /// Find the first match in [input] starting from [start].
   LuaMatch? firstMatch(String input, [int start = 0]) {
+    final literalPattern = _literalPattern;
+    if (literalPattern != null) {
+      final matchStart = input.indexOf(literalPattern, start);
+      if (matchStart < 0) {
+        return null;
+      }
+      return LuaMatch(
+        matchStart,
+        matchStart + literalPattern.length,
+        literalPattern,
+        const <String?>[],
+        const <int>{},
+      );
+    }
+
+    final parser = _parser!;
     for (var pos = start; pos <= input.length; pos++) {
-      final result = _parser.parseOn(Context(input, pos));
+      final result = parser.parseOn(Context(input, pos));
       if (result is Success) {
         final captures = List<String?>.from(_captures.take(_captureCount));
         return LuaMatch(
@@ -752,9 +808,30 @@ class LuaPattern {
 
   /// Iterate over all matches in [input] starting from [start].
   Iterable<LuaMatch> allMatches(String input, [int start = 0]) sync* {
+    final literalPattern = _literalPattern;
+    if (literalPattern != null) {
+      var pos = start;
+      while (pos <= input.length) {
+        final matchStart = input.indexOf(literalPattern, pos);
+        if (matchStart < 0) {
+          break;
+        }
+        yield LuaMatch(
+          matchStart,
+          matchStart + literalPattern.length,
+          literalPattern,
+          const <String?>[],
+          const <int>{},
+        );
+        pos = matchStart + literalPattern.length;
+      }
+      return;
+    }
+
+    final parser = _parser!;
     var pos = start;
     while (pos <= input.length) {
-      final result = _parser.parseOn(Context(input, pos));
+      final result = parser.parseOn(Context(input, pos));
       if (result is Success) {
         final captures = List<String?>.from(_captures.take(_captureCount));
         yield LuaMatch(
@@ -770,4 +847,35 @@ class LuaPattern {
       }
     }
   }
+}
+
+String? _plainLiteralPattern(String pattern) {
+  if (pattern.isEmpty) {
+    return null;
+  }
+  for (var index = 0; index < pattern.length; index++) {
+    if (_isMagicPatternCodeUnit(pattern.codeUnitAt(index))) {
+      return null;
+    }
+  }
+  return pattern;
+}
+
+bool _isMagicPatternCodeUnit(int codeUnit) {
+  switch (codeUnit) {
+    case 0x25: // %
+    case 0x5E: // ^
+    case 0x24: // $
+    case 0x28: // (
+    case 0x29: // )
+    case 0x2E: // .
+    case 0x5B: // [
+    case 0x5D: // ]
+    case 0x2A: // *
+    case 0x2B: // +
+    case 0x2D: // -
+    case 0x3F: // ?
+      return true;
+  }
+  return false;
 }

--- a/pkgs/lualike/lib/src/parsers/string.dart
+++ b/pkgs/lualike/lib/src/parsers/string.dart
@@ -12,6 +12,12 @@ class Utf8DecodeResult {
 
 /// A PetitParser-based parser for Lua string literals that handles escape sequences correctly
 class LuaStringParser {
+  static final RegExp _hexEscapePattern = RegExp(r'\\x([0-9A-Fa-f]{2})');
+  static final Parser<List<int>> _stringContentParser = build().end();
+  static final Parser<List<int>> _byteStringContentParser = build(
+    sourceCodeUnitsAreBytes: true,
+  ).end();
+
   /// Encode an invalid Unicode code point as raw bytes that will be detected as invalid UTF-8
   static List<int> _encodeInvalidCodePoint(int codePoint) {
     // For invalid code points, we need to create the UTF-8 byte sequence
@@ -356,15 +362,17 @@ class LuaStringParser {
   }) {
     // Normalize \xHH (hex escapes) to decimal escapes (\ddd) so that
     // downstream parsing always sees a single uniform form for byte escapes.
-    final hexRe = RegExp(r'\\x([0-9A-Fa-f]{2})');
-    final normalized = content.replaceAllMapped(hexRe, (m) {
-      final v = int.parse(m.group(1)!, radix: 16);
-      return '\\$v';
-    });
+    final normalized = content.contains(r'\x')
+        ? content.replaceAllMapped(_hexEscapePattern, (m) {
+            final v = int.parse(m.group(1)!, radix: 16);
+            return '\\$v';
+          })
+        : content;
 
-    final result = build(
-      sourceCodeUnitsAreBytes: sourceCodeUnitsAreBytes,
-    ).end().parse(normalized);
+    final parser = sourceCodeUnitsAreBytes
+        ? _byteStringContentParser
+        : _stringContentParser;
+    final result = parser.parse(normalized);
 
     if (result is Success) {
       return result.value;

--- a/pkgs/lualike/lib/src/parsers/string.dart
+++ b/pkgs/lualike/lib/src/parsers/string.dart
@@ -12,12 +12,6 @@ class Utf8DecodeResult {
 
 /// A PetitParser-based parser for Lua string literals that handles escape sequences correctly
 class LuaStringParser {
-  static final RegExp _hexEscapePattern = RegExp(r'\\x([0-9A-Fa-f]{2})');
-  static final Parser<List<int>> _stringContentParser = build().end();
-  static final Parser<List<int>> _byteStringContentParser = build(
-    sourceCodeUnitsAreBytes: true,
-  ).end();
-
   /// Encode an invalid Unicode code point as raw bytes that will be detected as invalid UTF-8
   static List<int> _encodeInvalidCodePoint(int codePoint) {
     // For invalid code points, we need to create the UTF-8 byte sequence
@@ -360,33 +354,292 @@ class LuaStringParser {
     String content, {
     bool sourceCodeUnitsAreBytes = false,
   }) {
-    // Normalize \xHH (hex escapes) to decimal escapes (\ddd) so that
-    // downstream parsing always sees a single uniform form for byte escapes.
-    final normalized = content.contains(r'\x')
-        ? content.replaceAllMapped(_hexEscapePattern, (m) {
-            final v = int.parse(m.group(1)!, radix: 16);
-            return '\\$v';
-          })
-        : content;
+    final result = <int>[];
+    var current = 0;
 
-    final parser = sourceCodeUnitsAreBytes
-        ? _byteStringContentParser
-        : _stringContentParser;
-    final result = parser.parse(normalized);
-
-    if (result is Success) {
-      return result.value;
-    } else {
-      // If the raw content contains a newline and we failed to parse,
-      // this is most likely an unfinished short string. Report it in
-      // Lua style so higher layers can surface the right message.
-      if (content.contains('\n') || content.contains('\r')) {
+    while (current < content.length) {
+      final codeUnit = content.codeUnitAt(current);
+      if (codeUnit == 0x5C) {
+        current = _parseEscape(content, current, result);
+        continue;
+      }
+      if (codeUnit == 0x0A || codeUnit == 0x0D) {
         throw const FormatException(
           "[string \"\"]:1: unfinished string near '<eof>'",
         );
       }
-      throw FormatException('Failed to parse Lua string: ${result.toString()}');
+
+      final start = current;
+      current++;
+      while (current < content.length) {
+        final next = content.codeUnitAt(current);
+        if (next == 0x5C || next == 0x0A || next == 0x0D) {
+          break;
+        }
+        current++;
+      }
+      _appendRegularBytes(
+        content,
+        start,
+        current,
+        result,
+        sourceCodeUnitsAreBytes: sourceCodeUnitsAreBytes,
+      );
     }
+
+    return result;
+  }
+
+  static int _parseEscape(String content, int position, List<int> result) {
+    final nextIndex = position + 1;
+    if (nextIndex >= content.length) {
+      throw const FormatException('Failed to parse Lua string: unexpected end');
+    }
+
+    final next = content.codeUnitAt(nextIndex);
+    switch (next) {
+      case 0x61: // a
+        result.add(7);
+        return nextIndex + 1;
+      case 0x62: // b
+        result.add(8);
+        return nextIndex + 1;
+      case 0x66: // f
+        result.add(12);
+        return nextIndex + 1;
+      case 0x6E: // n
+        result.add(10);
+        return nextIndex + 1;
+      case 0x72: // r
+        result.add(13);
+        return nextIndex + 1;
+      case 0x74: // t
+        result.add(9);
+        return nextIndex + 1;
+      case 0x76: // v
+        result.add(11);
+        return nextIndex + 1;
+      case 0x22: // "
+        result.add(34);
+        return nextIndex + 1;
+      case 0x27: // '
+        result.add(39);
+        return nextIndex + 1;
+      case 0x5C: // backslash
+        result.add(92);
+        return nextIndex + 1;
+      case 0x0D: // CR
+        result.add(10);
+        if (nextIndex + 1 < content.length &&
+            content.codeUnitAt(nextIndex + 1) == 0x0A) {
+          return nextIndex + 2;
+        }
+        return nextIndex + 1;
+      case 0x0A: // LF
+        result.add(10);
+        if (nextIndex + 1 < content.length &&
+            content.codeUnitAt(nextIndex + 1) == 0x0D) {
+          return nextIndex + 2;
+        }
+        return nextIndex + 1;
+      case 0x7A: // z
+        return _skipStringWhitespace(content, nextIndex + 1);
+      case 0x78: // x
+        return _parseHexEscape(content, position, result);
+      case 0x75: // u
+        return _parseUnicodeEscape(content, position, result);
+    }
+
+    if (_isDigit(next)) {
+      return _parseDecimalEscape(content, nextIndex, result);
+    }
+
+    final escaped = content[nextIndex];
+    throw FormatException('invalid escape sequence near "\\$escaped"');
+  }
+
+  static int _parseDecimalEscape(
+    String content,
+    int digitStart,
+    List<int> result,
+  ) {
+    var current = digitStart;
+    final maxEnd = digitStart + 3 < content.length
+        ? digitStart + 3
+        : content.length;
+    while (current < maxEnd && _isDigit(content.codeUnitAt(current))) {
+      current++;
+    }
+    final value = int.parse(content.substring(digitStart, current));
+    if (value > 255) {
+      throw FormatException('decimal escape too large');
+    }
+    result.add(value);
+    return current;
+  }
+
+  static int _parseHexEscape(String content, int position, List<int> result) {
+    final first = position + 2;
+    if (first >= content.length) {
+      throw FormatException('hexadecimal digit expected|incomplete');
+    }
+    if (!_isHexDigit(content.codeUnitAt(first))) {
+      throw FormatException('hexadecimal digit expected|invalid');
+    }
+
+    final second = first + 1;
+    if (second >= content.length) {
+      throw FormatException('hexadecimal digit expected|incomplete');
+    }
+    if (!_isHexDigit(content.codeUnitAt(second))) {
+      throw FormatException('hexadecimal digit expected|invalid');
+    }
+
+    result.add(int.parse(content.substring(first, second + 1), radix: 16));
+    return second + 1;
+  }
+
+  static int _parseUnicodeEscape(
+    String content,
+    int position,
+    List<int> result,
+  ) {
+    final openBrace = position + 2;
+    if (openBrace >= content.length) {
+      throw FormatException('missing \'{\' near|context:u"');
+    }
+
+    final open = content.codeUnitAt(openBrace);
+    if (open != 0x7B) {
+      if (_isHexDigit(open)) {
+        throw FormatException(
+          "missing '{' near|context:u${content[openBrace]}",
+        );
+      }
+      final followingEnd = _scanUntilUnicodeBraceOrHex(content, openBrace);
+      throw FormatException(
+        "missing '{' near|context:u${content.substring(openBrace, followingEnd)}",
+      );
+    }
+
+    final digitStart = openBrace + 1;
+    var digitEnd = digitStart;
+    while (digitEnd < content.length &&
+        _isHexDigit(content.codeUnitAt(digitEnd))) {
+      digitEnd++;
+    }
+
+    if (digitEnd == digitStart) {
+      if (digitEnd >= content.length) {
+        throw FormatException('missing \'}\' near|context:u{"');
+      }
+      if (content.codeUnitAt(digitEnd) == 0x7D) {
+        throw FormatException('hexadecimal digit expected near|context:u{');
+      }
+      final followingEnd = _scanUntilUnicodeBraceOrHex(content, digitEnd);
+      throw FormatException(
+        "missing '}' near|context:u{${content.substring(digitEnd, followingEnd)}",
+      );
+    }
+
+    if (digitEnd >= content.length) {
+      throw FormatException(
+        'missing \'}\' near|context:u{${content.substring(digitStart)}"',
+      );
+    }
+    if (content.codeUnitAt(digitEnd) != 0x7D) {
+      final followingEnd = _scanUntilUnicodeBraceOrHex(content, digitEnd);
+      throw FormatException(
+        "missing '}' near|context:u{${content.substring(digitStart, followingEnd)}",
+      );
+    }
+
+    final hex = content.substring(digitStart, digitEnd);
+    final codePoint = int.parse(hex, radix: 16);
+    if (codePoint > 0x7FFFFFFF) {
+      throw FormatException('UTF-8 value too large|context:u{$hex');
+    }
+
+    result.addAll(encodeCodePoint(codePoint));
+    return digitEnd + 1;
+  }
+
+  static void _appendRegularBytes(
+    String content,
+    int start,
+    int end,
+    List<int> result, {
+    required bool sourceCodeUnitsAreBytes,
+  }) {
+    var current = start;
+    while (current < end) {
+      final codeUnit = content.codeUnitAt(current);
+      if (codeUnit <= 0x7F) {
+        result.add(codeUnit);
+        current++;
+      } else if (sourceCodeUnitsAreBytes && codeUnit <= 0xFF) {
+        result.add(codeUnit);
+        current++;
+      } else if (_isLeadingSurrogate(codeUnit) &&
+          current + 1 < end &&
+          _isTrailingSurrogate(content.codeUnitAt(current + 1))) {
+        final next = content.codeUnitAt(current + 1);
+        final codePoint =
+            0x10000 + ((codeUnit - 0xD800) << 10) + (next - 0xDC00);
+        result.addAll(convert.utf8.encode(String.fromCharCode(codePoint)));
+        current += 2;
+      } else {
+        result.addAll(convert.utf8.encode(String.fromCharCode(codeUnit)));
+        current++;
+      }
+    }
+  }
+
+  static int _skipStringWhitespace(String content, int position) {
+    var current = position;
+    while (current < content.length &&
+        _isStringWhitespace(content.codeUnitAt(current))) {
+      current++;
+    }
+    return current;
+  }
+
+  static int _scanUntilUnicodeBraceOrHex(String content, int position) {
+    var current = position;
+    while (current < content.length) {
+      final codeUnit = content.codeUnitAt(current);
+      if (codeUnit == 0x7B || codeUnit == 0x7D || _isHexDigit(codeUnit)) {
+        break;
+      }
+      current++;
+    }
+    return current;
+  }
+
+  static bool _isDigit(int codeUnit) => codeUnit >= 0x30 && codeUnit <= 0x39;
+
+  static bool _isHexDigit(int codeUnit) =>
+      (codeUnit >= 0x30 && codeUnit <= 0x39) ||
+      (codeUnit >= 0x41 && codeUnit <= 0x46) ||
+      (codeUnit >= 0x61 && codeUnit <= 0x66);
+
+  static bool _isLeadingSurrogate(int codeUnit) =>
+      codeUnit >= 0xD800 && codeUnit <= 0xDBFF;
+
+  static bool _isTrailingSurrogate(int codeUnit) =>
+      codeUnit >= 0xDC00 && codeUnit <= 0xDFFF;
+
+  static bool _isStringWhitespace(int codeUnit) {
+    switch (codeUnit) {
+      case 0x20: // space
+      case 0x09: // tab
+      case 0x0D: // CR
+      case 0x0A: // LF
+      case 0x0C: // FF
+      case 0x0B: // VT
+        return true;
+    }
+    return false;
   }
 
   // ************************************************************

--- a/pkgs/lualike/lib/src/stdlib/lib_debug.dart
+++ b/pkgs/lualike/lib/src/stdlib/lib_debug.dart
@@ -1432,13 +1432,17 @@ class _Traceback extends BuiltinFunction {
     }
     if (source.startsWith('@')) {
       final raw = source.substring(1);
-      if (raw.contains('\n') ||
-          raw.length > 120 ||
-          raw.contains('%0A') ||
-          raw.contains('%20')) {
+      final basename = raw.split(RegExp(r'[/\\]')).last;
+      if (raw.contains('\n') || raw.contains('%0A') || raw.contains('%20')) {
         return _tracebackStringChunk(raw);
       }
-      return raw.split('/').last;
+      if (basename.isNotEmpty) {
+        return basename;
+      }
+      if (raw.length > 120) {
+        return _tracebackStringChunk(raw);
+      }
+      return raw;
     }
     if (source.startsWith('[string')) {
       return source;

--- a/pkgs/lualike/luascripts/parser_profiles/attributes_and_labels.lua
+++ b/pkgs/lualike/luascripts/parser_profiles/attributes_and_labels.lua
@@ -1,0 +1,10 @@
+local<const> limit = 4
+local total = 0
+
+::again::
+total = total + limit
+if total < 16 then
+  goto again
+end
+
+return total

--- a/pkgs/lualike/luascripts/parser_profiles/branches_and_loops.lua
+++ b/pkgs/lualike/luascripts/parser_profiles/branches_and_loops.lua
@@ -1,0 +1,21 @@
+local total = 0
+
+for i = 1, 6 do
+  if i % 2 == 0 then
+    total = total + i
+  elseif i == 3 then
+    total = total + 30
+  else
+    total = total - 1
+  end
+end
+
+while total < 60 do
+  total = total + 7
+end
+
+repeat
+  total = total - 3
+until total < 50
+
+return total

--- a/pkgs/lualike/luascripts/parser_profiles/functions_and_calls.lua
+++ b/pkgs/lualike/luascripts/parser_profiles/functions_and_calls.lua
@@ -1,0 +1,14 @@
+local function pair(a, b)
+  return a + b, a - b
+end
+
+local function fold(seed, ...)
+  local total = seed
+  for _, value in ipairs({...}) do
+    total = total + value
+  end
+  return total
+end
+
+local plus, minus = pair(10, 4)
+return fold(plus, minus, pair(3, 1))

--- a/pkgs/lualike/luascripts/parser_profiles/literals_and_expressions.lua
+++ b/pkgs/lualike/luascripts/parser_profiles/literals_and_expressions.lua
@@ -1,0 +1,5 @@
+local alpha = 0x1p+4 + 12.5e-1
+local beta = ((alpha * 3) // 2) % 7
+local gamma = not false and (beta >= 0 or alpha < 0)
+
+return alpha, beta, gamma, nil

--- a/pkgs/lualike/luascripts/parser_profiles/strings_and_comments.lua
+++ b/pkgs/lualike/luascripts/parser_profiles/strings_and_comments.lua
@@ -1,0 +1,12 @@
+-- Plain strings, escapes, line comments, and long brackets.
+local plain = "hello\nworld"
+local quoted = 'single quoted'
+local block = [=[
+line one
+line two
+]=]
+--[==[
+The parser should skip this whole long comment.
+]==]
+
+return plain .. quoted .. block

--- a/pkgs/lualike/luascripts/parser_profiles/table_shapes.lua
+++ b/pkgs/lualike/luascripts/parser_profiles/table_shapes.lua
@@ -1,0 +1,11 @@
+local data = {
+  name = "profile",
+  values = {1, 2, 3, 4},
+  nested = {
+    ["with space"] = true,
+    [{1, 2, 3}] = "table-key",
+  },
+}
+
+data.values[#data.values + 1] = 5
+return data.name, data.values[5], data.nested["with space"]

--- a/pkgs/lualike/test/parsers/number_literal_test.dart
+++ b/pkgs/lualike/test/parsers/number_literal_test.dart
@@ -1,0 +1,22 @@
+import 'package:lualike/src/ast.dart';
+import 'package:lualike/src/parse.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('number literals', () {
+    test('parses decimal and hexadecimal numeric forms', () {
+      final program = parse('return 123, 1.5, .5, 1e3, 1.e-2, 0xFF, 0x1.8p+4');
+      final statement = program.statements.single as ReturnStatement;
+      final values = statement.expr.cast<NumberLiteral>().map((literal) {
+        return literal.value;
+      }).toList();
+
+      expect(values, equals([123, 1.5, 0.5, 1000.0, 0.01, 255, 24.0]));
+    });
+
+    test('rejects malformed numeric suffixes', () {
+      expect(() => parse('return 0x.'), throwsA(isA<FormatException>()));
+      expect(() => parse('return 1..2'), throwsA(isA<FormatException>()));
+    });
+  });
+}

--- a/pkgs/lualike/tool/README.md
+++ b/pkgs/lualike/tool/README.md
@@ -95,6 +95,61 @@ dart run tool/compare.dart script.lua
 
 This tool runs the same code in both Lualike and reference Lua, showing any differences in output.
 
+## Parser Profile Tool (`parser_profile.dart`)
+
+Focused harness for profiling the PetitParser Lua grammar against small Lua
+source files in `luascripts/parser_profiles`.
+
+PetitParser's README recommends small reproducible grammar inputs, the
+reflection linter for common inefficient or invalid parser graphs, `trace()`
+for parser entry/exit flow, `profile()` for activation counts and inclusive
+time, and `progress()` for spotting parser movement and backtracking. This tool
+wraps those hooks around Lualike's real `LuaGrammarDefinition`.
+
+### Basic Usage
+
+```bash
+# Time the whole parser-profile corpus
+dart run tool/parser_profile.dart
+
+# Add PetitParser profile rows for every corpus script
+dart run tool/parser_profile.dart --profile --top=20
+
+# Inspect one small case with trace output
+dart run tool/parser_profile.dart --case table_shapes --trace --trace-limit=80
+
+# Summarize parser movement and backtracking for one case
+dart run tool/parser_profile.dart --case branches_and_loops --progress
+
+# Run the PetitParser grammar linter before timing the corpus
+dart run tool/parser_profile.dart --lint
+
+# Include extra Lua files or directories
+dart run tool/parser_profile.dart --path luascripts/test/math.lua
+
+# Save a timing snapshot as JSON
+dart run tool/parser_profile.dart --label current --json-out benchmarks/parser_profiles/current-small.json
+
+# Compare two saved snapshots and generate Markdown
+dart run tool/parser_profile_compare.dart \
+  --baseline benchmarks/parser_profiles/baseline-small.json \
+  --latest benchmarks/parser_profiles/current-small.json \
+  --markdown-out benchmarks/parser_profiles/current-small-summary.md
+
+# Generate baseline/current snapshots and comparison reports automatically
+dart run tool/parser_profile_snapshot.dart --baseline-ref origin/ir
+```
+
+The default corpus is intentionally small and grammar-shaped rather than a
+runtime benchmark. Add new `.lua` files under `luascripts/parser_profiles`
+whenever a parser change needs a targeted repro.
+
+`parser_profile_snapshot.dart` creates a temporary detached worktree for the
+baseline ref, copies the profiling harness into it, runs the small parser corpus
+and hot Lua suite in both trees, then writes JSON and Markdown reports under
+`benchmarks/parser_profiles`. That directory is ignored by git, so these
+snapshots stay local unless explicitly moved or unignored.
+
 
 ## Examples
 

--- a/pkgs/lualike/tool/parser_profile.dart
+++ b/pkgs/lualike/tool/parser_profile.dart
@@ -1,0 +1,753 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:args/args.dart';
+import 'package:lualike/src/parse.dart' as parse_api;
+import 'package:lualike/src/parsers/lua.dart' as lua_parser;
+import 'package:path/path.dart' as path;
+import 'package:petitparser/debug.dart' as pp_debug;
+import 'package:petitparser/petitparser.dart';
+import 'package:petitparser/reflection.dart' as pp_reflection;
+import 'package:source_span/source_span.dart';
+
+const _defaultCorpusDirectory = 'luascripts/parser_profiles';
+
+Future<void> main(List<String> args) async {
+  final parser = ArgParser()
+    ..addOption(
+      'corpus',
+      help: 'Corpus directory, relative to the lualike package root.',
+      defaultsTo: _defaultCorpusDirectory,
+    )
+    ..addMultiOption(
+      'case',
+      abbr: 'c',
+      help: 'Corpus case name without .lua. Repeat to run several cases.',
+    )
+    ..addMultiOption(
+      'path',
+      abbr: 'p',
+      help: 'Additional Lua file or directory to include.',
+    )
+    ..addOption(
+      'warmup',
+      help: 'Warmup parses before measured runs.',
+      defaultsTo: '5',
+    )
+    ..addOption('repeat', help: 'Measured parses per script.', defaultsTo: '30')
+    ..addOption(
+      'top',
+      help: 'Profile rows to print for elapsed time and activation counts.',
+      defaultsTo: '15',
+    )
+    ..addOption('label', help: 'Optional label written to JSON snapshots.')
+    ..addOption('json-out', help: 'Write timing results as JSON to this file.')
+    ..addFlag(
+      'profile',
+      help: 'Run petitparser profile() for each script.',
+      defaultsTo: false,
+    )
+    ..addFlag(
+      'trace',
+      help: 'Run petitparser trace() for each script.',
+      defaultsTo: false,
+    )
+    ..addOption(
+      'trace-limit',
+      help: 'Maximum trace events to print per script.',
+      defaultsTo: '120',
+    )
+    ..addFlag(
+      'progress',
+      help: 'Run petitparser progress() and summarize parser movement.',
+      defaultsTo: false,
+    )
+    ..addOption(
+      'progress-limit',
+      help: 'Maximum progress events to print per script.',
+      defaultsTo: '80',
+    )
+    ..addFlag(
+      'lint',
+      help: 'Run the petitparser reflection linter against the Lua grammar.',
+      defaultsTo: false,
+    )
+    ..addFlag(
+      'fail-fast',
+      help: 'Stop after the first parse failure.',
+      defaultsTo: true,
+    )
+    ..addFlag('help', abbr: 'h', help: 'Print usage.', negatable: false);
+
+  final options = parser.parse(args);
+  if (options.flag('help')) {
+    stdout.writeln('Lua grammar parser profiling harness');
+    stdout.writeln(parser.usage);
+    return;
+  }
+
+  final packageRoot = _findPackageRoot();
+  final corpusDirectory = path.normalize(
+    path.join(packageRoot, options.option('corpus')!),
+  );
+  final scripts = _loadScripts(
+    corpusDirectory: corpusDirectory,
+    packageRoot: packageRoot,
+    caseNames: options.multiOption('case'),
+    extraPaths: options.multiOption('path'),
+  );
+
+  if (scripts.isEmpty) {
+    stderr.writeln('No parser profile scripts found.');
+    exitCode = 64;
+    return;
+  }
+
+  final config = _ProfileConfig(
+    warmup: _parsePositiveInt(options.option('warmup')!, 'warmup'),
+    repeat: _parsePositiveInt(options.option('repeat')!, 'repeat'),
+    top: _parsePositiveInt(options.option('top')!, 'top'),
+    profile: options.flag('profile'),
+    trace: options.flag('trace'),
+    traceLimit: _parsePositiveInt(
+      options.option('trace-limit')!,
+      'trace-limit',
+    ),
+    progress: options.flag('progress'),
+    progressLimit: _parsePositiveInt(
+      options.option('progress-limit')!,
+      'progress-limit',
+    ),
+    lint: options.flag('lint'),
+    failFast: options.flag('fail-fast'),
+  );
+
+  stdout.writeln('Lua parser profile corpus: $corpusDirectory');
+  stdout.writeln(
+    'scripts=${scripts.length} warmup=${config.warmup} '
+    'repeat=${config.repeat}',
+  );
+  stdout.writeln('');
+
+  if (config.lint) {
+    _runLinter(scripts.first);
+    stdout.writeln('');
+  }
+
+  final stats = <_ParseStats>[];
+  for (final script in scripts) {
+    try {
+      final result = _timeScript(script, config);
+      stats.add(result);
+      _printStats(result);
+
+      if (config.profile) {
+        _runProfile(script, top: config.top);
+      }
+      if (config.progress) {
+        _runProgress(script, limit: config.progressLimit);
+      }
+      if (config.trace) {
+        _runTrace(script, limit: config.traceLimit);
+      }
+    } catch (error, stackTrace) {
+      stderr.writeln('Failed while parsing ${script.name}: $error');
+      if (config.failFast) {
+        stderr.writeln(stackTrace);
+        exitCode = 1;
+        return;
+      }
+    }
+  }
+
+  _printSummary(stats);
+
+  final jsonOut = options.option('json-out');
+  if (jsonOut != null) {
+    _writeJsonSnapshot(
+      packageRoot: packageRoot,
+      corpusDirectory: corpusDirectory,
+      arguments: args,
+      label: options.option('label'),
+      config: config,
+      stats: stats,
+      outputPath: jsonOut,
+    );
+  }
+}
+
+final class _ProfileConfig {
+  const _ProfileConfig({
+    required this.warmup,
+    required this.repeat,
+    required this.top,
+    required this.profile,
+    required this.trace,
+    required this.traceLimit,
+    required this.progress,
+    required this.progressLimit,
+    required this.lint,
+    required this.failFast,
+  });
+
+  final int warmup;
+  final int repeat;
+  final int top;
+  final bool profile;
+  final bool trace;
+  final int traceLimit;
+  final bool progress;
+  final int progressLimit;
+  final bool lint;
+  final bool failFast;
+}
+
+final class _LuaScript {
+  const _LuaScript({
+    required this.name,
+    required this.path,
+    required this.source,
+    required this.sourceEncoding,
+  });
+
+  final String name;
+  final String path;
+  final String source;
+  final String sourceEncoding;
+
+  int get charCount => source.length;
+
+  int get lineCount => '\n'.allMatches(source).length + 1;
+}
+
+final class _ParseStats {
+  const _ParseStats({required this.script, required this.samplesMicros});
+
+  final _LuaScript script;
+  final List<int> samplesMicros;
+
+  int get minMicros => samplesMicros.reduce(math.min);
+
+  int get maxMicros => samplesMicros.reduce(math.max);
+
+  double get meanMicros =>
+      samplesMicros.reduce((left, right) => left + right) /
+      samplesMicros.length;
+
+  double get medianMicros {
+    final sorted = List<int>.from(samplesMicros)..sort();
+    final middle = sorted.length ~/ 2;
+    if (sorted.length.isOdd) {
+      return sorted[middle].toDouble();
+    }
+    return (sorted[middle - 1] + sorted[middle]) / 2;
+  }
+
+  double get charsPerSecond => script.charCount / (meanMicros / 1000000.0);
+}
+
+final class _ProfileFrame {
+  const _ProfileFrame({
+    required this.parserName,
+    required this.count,
+    required this.elapsedMicros,
+  });
+
+  final String parserName;
+  final int count;
+  final int elapsedMicros;
+}
+
+final class _AggregatedProfileFrame {
+  _AggregatedProfileFrame(this.parserName);
+
+  final String parserName;
+  var count = 0;
+  var elapsedMicros = 0;
+
+  void add(_ProfileFrame frame) {
+    count += frame.count;
+    elapsedMicros += frame.elapsedMicros;
+  }
+}
+
+final class _ProgressEvent {
+  const _ProgressEvent({required this.position, required this.parserName});
+
+  final int position;
+  final String parserName;
+}
+
+_ParseStats _timeScript(_LuaScript script, _ProfileConfig config) {
+  for (var i = 0; i < config.warmup; i++) {
+    parse_api.parse(script.source, url: script.path);
+  }
+
+  final samples = <int>[];
+  for (var i = 0; i < config.repeat; i++) {
+    final stopwatch = Stopwatch()..start();
+    parse_api.parse(script.source, url: script.path);
+    stopwatch.stop();
+    samples.add(stopwatch.elapsedMicroseconds);
+  }
+
+  return _ParseStats(script: script, samplesMicros: samples);
+}
+
+void _runLinter(_LuaScript script) {
+  final parser = _buildLuaParser(script);
+  final issues = pp_reflection.linter(parser);
+
+  stdout.writeln('PetitParser linter');
+  if (issues.isEmpty) {
+    stdout.writeln('  No issues found.');
+    return;
+  }
+
+  for (final issue in issues) {
+    stdout.writeln(
+      '  ${issue.type.name.padRight(7)} ${issue.title}: '
+      '${issue.parser}',
+    );
+    stdout.writeln('    ${issue.description}');
+  }
+}
+
+void _runProfile(_LuaScript script, {required int top}) {
+  final frames = <_ProfileFrame>[];
+  final profiled = pp_debug.profile(
+    _buildLuaParser(script),
+    output: (frame) {
+      frames.add(
+        _ProfileFrame(
+          parserName: frame.parser.toString(),
+          count: frame.count,
+          elapsedMicros: frame.elapsed.inMicroseconds,
+        ),
+      );
+    },
+  );
+
+  final result = profiled.parse(script.source);
+  _requireSuccess(script, result);
+
+  if (frames.isEmpty) {
+    stdout.writeln('  No PetitParser profile frames captured.');
+    return;
+  }
+
+  final aggregated = <String, _AggregatedProfileFrame>{};
+  for (final frame in frames) {
+    aggregated
+        .putIfAbsent(
+          frame.parserName,
+          () => _AggregatedProfileFrame(frame.parserName),
+        )
+        .add(frame);
+  }
+
+  final byTime = aggregated.values.toList()
+    ..sort((left, right) => right.elapsedMicros.compareTo(left.elapsedMicros));
+  final byCount = aggregated.values.toList()
+    ..sort((left, right) => right.count.compareTo(left.count));
+
+  stdout.writeln('  PetitParser profile: ${script.name}');
+  stdout.writeln('  Top $top by inclusive elapsed time');
+  for (final frame in byTime.take(top)) {
+    stdout.writeln(
+      '    ${_formatMicros(frame.elapsedMicros).padLeft(10)}  '
+      '${frame.count.toString().padLeft(8)}  ${frame.parserName}',
+    );
+  }
+
+  stdout.writeln('  Top $top by activation count');
+  for (final frame in byCount.take(top)) {
+    stdout.writeln(
+      '    ${frame.count.toString().padLeft(8)}  '
+      '${_formatMicros(frame.elapsedMicros).padLeft(10)}  '
+      '${frame.parserName}',
+    );
+  }
+}
+
+void _runProgress(_LuaScript script, {required int limit}) {
+  final events = <_ProgressEvent>[];
+  final progressed = pp_debug.progress(
+    _buildLuaParser(script),
+    output: (frame) {
+      events.add(
+        _ProgressEvent(
+          position: frame.position,
+          parserName: frame.parser.toString(),
+        ),
+      );
+    },
+  );
+
+  final result = progressed.parse(script.source);
+  _requireSuccess(script, result);
+
+  var backtracks = 0;
+  var maxBacktrack = 0;
+  var previous = 0;
+  for (final event in events) {
+    if (event.position < previous) {
+      backtracks++;
+      maxBacktrack = math.max(maxBacktrack, previous - event.position);
+    }
+    previous = event.position;
+  }
+
+  stdout.writeln('  PetitParser progress: ${script.name}');
+  stdout.writeln(
+    '    events=${events.length} backtracks=$backtracks '
+    'maxBacktrack=$maxBacktrack chars',
+  );
+
+  for (final (index, event) in events.take(limit).indexed) {
+    stdout.writeln(
+      '    ${index.toString().padLeft(4)} '
+      'pos=${event.position.toString().padLeft(4)} ${event.parserName}',
+    );
+  }
+  if (events.length > limit) {
+    stdout.writeln('    ... ${events.length - limit} progress events omitted');
+  }
+}
+
+void _runTrace(_LuaScript script, {required int limit}) {
+  final events = <pp_debug.TraceEvent>[];
+  var omitted = 0;
+  final traced = pp_debug.trace(
+    _buildLuaParser(script),
+    output: (event) {
+      if (events.length < limit) {
+        events.add(event);
+      } else {
+        omitted++;
+      }
+    },
+  );
+
+  final result = traced.parse(script.source);
+  _requireSuccess(script, result);
+
+  stdout.writeln('  PetitParser trace: ${script.name}');
+  for (final event in events) {
+    stdout.writeln('    ${_formatTraceEvent(event)}');
+  }
+  if (omitted > 0) {
+    stdout.writeln('    ... $omitted trace events omitted');
+  }
+}
+
+Parser _buildLuaParser(_LuaScript script) {
+  final sourceFile = SourceFile.fromString(
+    script.source,
+    url: Uri.file(script.path),
+  );
+  final definition = lua_parser.LuaGrammarDefinition(sourceFile);
+  return definition.build();
+}
+
+void _requireSuccess(_LuaScript script, Result result) {
+  if (result is Failure) {
+    throw FormatException(
+      '${script.name}: ${result.message} at ${result.position}',
+    );
+  }
+}
+
+String _formatTraceEvent(pp_debug.TraceEvent event) {
+  final indent = '  ' * event.level;
+  final result = event.result;
+  if (result == null) {
+    return '$indent> pos=${event.context.position} ${event.parser}';
+  }
+
+  final status = switch (result) {
+    Success(position: final position) => 'ok@$position',
+    Failure(message: final message, position: final position) =>
+      'fail@$position $message',
+  };
+  return '$indent< $status';
+}
+
+void _printStats(_ParseStats stats) {
+  stdout.writeln(
+    '${stats.script.name.padRight(24)} '
+    '${stats.script.charCount.toString().padLeft(5)} chars  '
+    '${stats.script.lineCount.toString().padLeft(3)} lines  '
+    '${stats.script.sourceEncoding.padRight(6)}  '
+    'mean ${_formatMicros(stats.meanMicros).padLeft(10)}  '
+    'median ${_formatMicros(stats.medianMicros).padLeft(10)}  '
+    'min ${_formatMicros(stats.minMicros).padLeft(10)}  '
+    'max ${_formatMicros(stats.maxMicros).padLeft(10)}  '
+    '${stats.charsPerSecond.toStringAsFixed(0).padLeft(9)} chars/s',
+  );
+}
+
+void _printSummary(List<_ParseStats> stats) {
+  if (stats.isEmpty) {
+    return;
+  }
+
+  final sorted = List<_ParseStats>.from(stats)
+    ..sort((left, right) => right.meanMicros.compareTo(left.meanMicros));
+
+  stdout.writeln('');
+  stdout.writeln('Slowest parser corpus cases');
+  for (final stats in sorted) {
+    stdout.writeln(
+      '  ${stats.script.name.padRight(24)} '
+      'mean ${_formatMicros(stats.meanMicros).padLeft(10)}  '
+      '${stats.charsPerSecond.toStringAsFixed(0).padLeft(9)} chars/s',
+    );
+  }
+}
+
+void _writeJsonSnapshot({
+  required String packageRoot,
+  required String corpusDirectory,
+  required List<String> arguments,
+  required String? label,
+  required _ProfileConfig config,
+  required List<_ParseStats> stats,
+  required String outputPath,
+}) {
+  final outputFile = File(
+    path.isAbsolute(outputPath)
+        ? outputPath
+        : path.join(packageRoot, outputPath),
+  );
+  outputFile.parent.createSync(recursive: true);
+  outputFile.writeAsStringSync(
+    '${const JsonEncoder.withIndent('  ').convert(_snapshotJson(packageRoot: packageRoot, corpusDirectory: corpusDirectory, arguments: arguments, label: label, config: config, stats: stats))}\n',
+  );
+
+  stdout.writeln('');
+  stdout.writeln('Wrote parser profile JSON: ${outputFile.path}');
+}
+
+Map<String, Object?> _snapshotJson({
+  required String packageRoot,
+  required String corpusDirectory,
+  required List<String> arguments,
+  required String? label,
+  required _ProfileConfig config,
+  required List<_ParseStats> stats,
+}) {
+  final totalMeanMicros = stats.fold<double>(
+    0,
+    (total, entry) => total + entry.meanMicros,
+  );
+  return {
+    'schemaVersion': 1,
+    'generatedBy': 'tool/parser_profile.dart',
+    'capturedAt': DateTime.now().toIso8601String(),
+    'label': label,
+    'packageRoot': packageRoot,
+    'git': _gitMetadata(packageRoot),
+    'corpus': {
+      'directory': corpusDirectory,
+      'relativeDirectory': path.relative(corpusDirectory, from: packageRoot),
+    },
+    'config': {
+      'warmup': config.warmup,
+      'repeat': config.repeat,
+      'profile': config.profile,
+      'trace': config.trace,
+      'progress': config.progress,
+      'lint': config.lint,
+      'failFast': config.failFast,
+    },
+    'arguments': arguments,
+    'rows': [
+      for (final entry in stats)
+        {
+          'case': entry.script.name,
+          'path': path.relative(entry.script.path, from: packageRoot),
+          'source': {
+            'characters': entry.script.charCount,
+            'lines': entry.script.lineCount,
+            'encoding': entry.script.sourceEncoding,
+          },
+          'samplesMicros': entry.samplesMicros,
+          'minMicros': entry.minMicros,
+          'meanMicros': entry.meanMicros,
+          'medianMicros': entry.medianMicros,
+          'maxMicros': entry.maxMicros,
+          'charsPerSecond': entry.charsPerSecond,
+        },
+    ],
+    'total': {'meanMicros': totalMeanMicros, 'meanMs': totalMeanMicros / 1000},
+  };
+}
+
+Map<String, Object?> _gitMetadata(String packageRoot) {
+  final revision = _gitOutput(packageRoot, ['rev-parse', 'HEAD']);
+  final branch = _gitOutput(packageRoot, ['branch', '--show-current']);
+  final status = _gitOutput(packageRoot, ['status', '--short']);
+  final statusLines = status == null || status.isEmpty
+      ? const <String>[]
+      : status.split('\n');
+  return {
+    'revision': revision,
+    'branch': branch?.isEmpty ?? true ? null : branch,
+    'dirty': statusLines.isNotEmpty,
+    'statusShort': statusLines,
+  };
+}
+
+String? _gitOutput(String packageRoot, List<String> arguments) {
+  final result = Process.runSync(
+    'git',
+    arguments,
+    workingDirectory: packageRoot,
+  );
+  if (result.exitCode != 0) {
+    return null;
+  }
+  return (result.stdout as String).trim();
+}
+
+List<_LuaScript> _loadScripts({
+  required String corpusDirectory,
+  required String packageRoot,
+  required List<String> caseNames,
+  required List<String> extraPaths,
+}) {
+  final scriptsByPath = <String, _LuaScript>{};
+
+  void addFile(File file) {
+    if (!file.path.endsWith('.lua')) {
+      return;
+    }
+    final normalizedPath = path.normalize(file.absolute.path);
+    final decoded = _decodeLuaSourceBytes(file.readAsBytesSync());
+    scriptsByPath[normalizedPath] = _LuaScript(
+      name: _scriptName(
+        corpusDirectory: corpusDirectory,
+        packageRoot: packageRoot,
+        normalizedPath: normalizedPath,
+      ),
+      path: normalizedPath,
+      source: decoded.source,
+      sourceEncoding: decoded.encoding,
+    );
+  }
+
+  if (caseNames.isEmpty) {
+    final directory = Directory(corpusDirectory);
+    if (directory.existsSync()) {
+      final entries =
+          directory.listSync(recursive: true).whereType<File>().toList()
+            ..sort((left, right) => left.path.compareTo(right.path));
+      for (final entry in entries) {
+        addFile(entry);
+      }
+    }
+  } else {
+    for (final caseName in caseNames) {
+      final file = File(path.join(corpusDirectory, '$caseName.lua'));
+      if (!file.existsSync()) {
+        throw ArgumentError.value(
+          caseName,
+          'case',
+          'No parser profile case at ${file.path}',
+        );
+      }
+      addFile(file);
+    }
+  }
+
+  for (final extraPath in extraPaths) {
+    final resolved = path.isAbsolute(extraPath)
+        ? extraPath
+        : path.join(packageRoot, extraPath);
+    final type = FileSystemEntity.typeSync(resolved);
+    if (type == FileSystemEntityType.file) {
+      addFile(File(resolved));
+    } else if (type == FileSystemEntityType.directory) {
+      final entries =
+          Directory(
+              resolved,
+            ).listSync(recursive: true).whereType<File>().toList()
+            ..sort((left, right) => left.path.compareTo(right.path));
+      for (final entry in entries) {
+        addFile(entry);
+      }
+    } else {
+      throw ArgumentError.value(extraPath, 'path', 'No such file or directory');
+    }
+  }
+
+  return scriptsByPath.values.toList()
+    ..sort((left, right) => left.name.compareTo(right.name));
+}
+
+({String source, String encoding}) _decodeLuaSourceBytes(List<int> bytes) {
+  try {
+    return (source: utf8.decode(bytes), encoding: 'utf8');
+  } on FormatException {
+    return (
+      source: latin1.decode(bytes, allowInvalid: true),
+      encoding: 'latin1',
+    );
+  }
+}
+
+String _scriptName({
+  required String corpusDirectory,
+  required String packageRoot,
+  required String normalizedPath,
+}) {
+  final relativeToCorpus = path.relative(normalizedPath, from: corpusDirectory);
+  final relativePath =
+      !relativeToCorpus.startsWith('..') && !path.isAbsolute(relativeToCorpus)
+      ? relativeToCorpus
+      : path.relative(normalizedPath, from: packageRoot);
+  return path.withoutExtension(relativePath).replaceAll(path.separator, '/');
+}
+
+String _findPackageRoot() {
+  var current = path.normalize(Directory.current.absolute.path);
+  while (true) {
+    final pubspec = File(path.join(current, 'pubspec.yaml'));
+    final parserCorpus = Directory(path.join(current, _defaultCorpusDirectory));
+    if (pubspec.existsSync() && parserCorpus.existsSync()) {
+      return current;
+    }
+
+    final nestedPackage = path.join(current, 'pkgs', 'lualike');
+    final nestedPubspec = File(path.join(nestedPackage, 'pubspec.yaml'));
+    final nestedCorpus = Directory(
+      path.join(nestedPackage, _defaultCorpusDirectory),
+    );
+    if (nestedPubspec.existsSync() && nestedCorpus.existsSync()) {
+      return nestedPackage;
+    }
+
+    final parent = path.dirname(current);
+    if (parent == current) {
+      throw StateError('Could not find the lualike package root.');
+    }
+    current = parent;
+  }
+}
+
+int _parsePositiveInt(String value, String name) {
+  final parsed = int.tryParse(value);
+  if (parsed == null || parsed <= 0) {
+    throw ArgumentError.value(value, name, 'Expected a positive integer');
+  }
+  return parsed;
+}
+
+String _formatMicros(num micros) {
+  if (micros >= 1000) {
+    return '${(micros / 1000).toStringAsFixed(3)} ms';
+  }
+  return '${micros.toStringAsFixed(0)} us';
+}

--- a/pkgs/lualike/tool/parser_profile_compare.dart
+++ b/pkgs/lualike/tool/parser_profile_compare.dart
@@ -1,0 +1,325 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:path/path.dart' as path;
+
+Future<void> main(List<String> args) async {
+  final parser = ArgParser()
+    ..addOption('baseline', help: 'Baseline JSON from parser_profile.dart.')
+    ..addOption('latest', help: 'Latest JSON from parser_profile.dart.')
+    ..addOption(
+      'title',
+      help: 'Markdown report title.',
+      defaultsTo: 'Parser Profile Comparison',
+    )
+    ..addOption('json-out', help: 'Write comparison data as JSON.')
+    ..addOption('markdown-out', help: 'Write comparison as Markdown.')
+    ..addFlag('help', abbr: 'h', negatable: false, help: 'Print usage.');
+
+  final options = parser.parse(args);
+  if (options.flag('help')) {
+    stdout.writeln('Compare parser profile JSON snapshots.');
+    stdout.writeln(parser.usage);
+    return;
+  }
+
+  final baselinePath = options.option('baseline');
+  final latestPath = options.option('latest');
+  if (baselinePath == null || latestPath == null) {
+    stderr.writeln('Both --baseline and --latest are required.');
+    stderr.writeln(parser.usage);
+    exitCode = 64;
+    return;
+  }
+
+  final baseline = _readJsonFile(baselinePath);
+  final latest = _readJsonFile(latestPath);
+  final comparison = _compareSnapshots(
+    title: options.option('title')!,
+    baseline: baseline,
+    latest: latest,
+  );
+
+  final jsonOut = options.option('json-out');
+  if (jsonOut != null) {
+    _writeTextFile(
+      jsonOut,
+      '${const JsonEncoder.withIndent('  ').convert(comparison.toJson())}\n',
+    );
+  }
+
+  final markdown = comparison.toMarkdown();
+  final markdownOut = options.option('markdown-out');
+  if (markdownOut == null) {
+    stdout.write(markdown);
+  } else {
+    _writeTextFile(markdownOut, markdown);
+  }
+}
+
+Map<String, Object?> _readJsonFile(String filePath) {
+  final decoded = jsonDecode(File(filePath).readAsStringSync());
+  if (decoded is! Map<String, Object?>) {
+    throw FormatException('Expected JSON object in $filePath');
+  }
+  return decoded;
+}
+
+void _writeTextFile(String filePath, String contents) {
+  final file = File(filePath);
+  file.parent.createSync(recursive: true);
+  file.writeAsStringSync(contents);
+  stdout.writeln('Wrote ${path.normalize(file.path)}');
+}
+
+_Comparison _compareSnapshots({
+  required String title,
+  required Map<String, Object?> baseline,
+  required Map<String, Object?> latest,
+}) {
+  final baselineRows = _rowsByCase(baseline);
+  final rows = <_ComparisonRow>[];
+
+  for (final latestRow in _snapshotRows(latest)) {
+    final caseName = latestRow['case'] as String;
+    final baselineRow = baselineRows[caseName];
+    if (baselineRow == null) {
+      continue;
+    }
+    rows.add(
+      _ComparisonRow(
+        caseName: caseName,
+        baselineMeanMicros: _number(baselineRow['meanMicros']),
+        latestMeanMicros: _number(latestRow['meanMicros']),
+      ),
+    );
+  }
+
+  final baselineTotal = rows.fold<double>(
+    0,
+    (total, row) => total + row.baselineMeanMicros,
+  );
+  final latestTotal = rows.fold<double>(
+    0,
+    (total, row) => total + row.latestMeanMicros,
+  );
+
+  return _Comparison(
+    title: title,
+    generatedAt: DateTime.now(),
+    baseline: _SnapshotSummary.fromJson(baseline, fallbackLabel: 'baseline'),
+    latest: _SnapshotSummary.fromJson(latest, fallbackLabel: 'latest'),
+    rows: rows,
+    total: _ComparisonTotal(
+      baselineMeanMicros: baselineTotal,
+      latestMeanMicros: latestTotal,
+    ),
+  );
+}
+
+Map<String, Map<String, Object?>> _rowsByCase(Map<String, Object?> snapshot) {
+  return {
+    for (final row in _snapshotRows(snapshot)) row['case'] as String: row,
+  };
+}
+
+List<Map<String, Object?>> _snapshotRows(Map<String, Object?> snapshot) {
+  final rows = snapshot['rows'];
+  if (rows is! List) {
+    throw const FormatException('Snapshot missing rows list.');
+  }
+  return [
+    for (final row in rows)
+      if (row is Map<String, Object?>) row,
+  ];
+}
+
+double _number(Object? value) {
+  if (value is int) {
+    return value.toDouble();
+  }
+  if (value is double) {
+    return value;
+  }
+  throw FormatException('Expected number, got $value');
+}
+
+String _formatMs(double micros) => '${(micros / 1000).toStringAsFixed(3)} ms';
+
+String _formatPercent(double value) => '${value.toStringAsFixed(1)}%';
+
+String _formatSpeedup(double value) => '${value.toStringAsFixed(1)}x';
+
+String _shortRevision(String? revision) {
+  if (revision == null || revision.length <= 12) {
+    return revision ?? 'unknown';
+  }
+  return revision.substring(0, 12);
+}
+
+final class _SnapshotSummary {
+  const _SnapshotSummary({
+    required this.label,
+    required this.capturedAt,
+    required this.revision,
+    required this.branch,
+  });
+
+  factory _SnapshotSummary.fromJson(
+    Map<String, Object?> snapshot, {
+    required String fallbackLabel,
+  }) {
+    final git = snapshot['git'];
+    final gitMap = git is Map<String, Object?>
+        ? git
+        : const <String, Object?>{};
+    return _SnapshotSummary(
+      label: snapshot['label'] as String? ?? fallbackLabel,
+      capturedAt: snapshot['capturedAt'] as String?,
+      revision: gitMap['revision'] as String?,
+      branch: gitMap['branch'] as String?,
+    );
+  }
+
+  final String label;
+  final String? capturedAt;
+  final String? revision;
+  final String? branch;
+
+  Map<String, Object?> toJson() => {
+    'label': label,
+    'capturedAt': capturedAt,
+    'revision': revision,
+    'branch': branch,
+  };
+
+  String toMarkdownLine(String name) {
+    final pieces = <String>[
+      '$name: `$label`',
+      'revision `${_shortRevision(revision)}`',
+    ];
+    if (branch != null && branch!.isNotEmpty) {
+      pieces.add('branch `$branch`');
+    }
+    if (capturedAt != null) {
+      pieces.add('captured `$capturedAt`');
+    }
+    return pieces.join(', ');
+  }
+}
+
+final class _ComparisonRow {
+  const _ComparisonRow({
+    required this.caseName,
+    required this.baselineMeanMicros,
+    required this.latestMeanMicros,
+  });
+
+  final String caseName;
+  final double baselineMeanMicros;
+  final double latestMeanMicros;
+
+  double get reductionPercent =>
+      (baselineMeanMicros - latestMeanMicros) * 100 / baselineMeanMicros;
+
+  double get speedup => baselineMeanMicros / latestMeanMicros;
+
+  Map<String, Object?> toJson() => {
+    'case': caseName,
+    'baselineMeanMicros': baselineMeanMicros,
+    'latestMeanMicros': latestMeanMicros,
+    'timeReductionPercent': reductionPercent,
+    'speedup': speedup,
+  };
+}
+
+final class _ComparisonTotal {
+  const _ComparisonTotal({
+    required this.baselineMeanMicros,
+    required this.latestMeanMicros,
+  });
+
+  final double baselineMeanMicros;
+  final double latestMeanMicros;
+
+  double get reductionPercent =>
+      (baselineMeanMicros - latestMeanMicros) * 100 / baselineMeanMicros;
+
+  double get speedup => baselineMeanMicros / latestMeanMicros;
+
+  Map<String, Object?> toJson() => {
+    'baselineMeanMicros': baselineMeanMicros,
+    'latestMeanMicros': latestMeanMicros,
+    'timeReductionPercent': reductionPercent,
+    'speedup': speedup,
+  };
+}
+
+final class _Comparison {
+  const _Comparison({
+    required this.title,
+    required this.generatedAt,
+    required this.baseline,
+    required this.latest,
+    required this.rows,
+    required this.total,
+  });
+
+  final String title;
+  final DateTime generatedAt;
+  final _SnapshotSummary baseline;
+  final _SnapshotSummary latest;
+  final List<_ComparisonRow> rows;
+  final _ComparisonTotal total;
+
+  Map<String, Object?> toJson() => {
+    'schemaVersion': 1,
+    'generatedBy': 'tool/parser_profile_compare.dart',
+    'title': title,
+    'generatedAt': generatedAt.toIso8601String(),
+    'baseline': baseline.toJson(),
+    'latest': latest.toJson(),
+    'rows': [for (final row in rows) row.toJson()],
+    'total': total.toJson(),
+  };
+
+  String toMarkdown() {
+    final buffer = StringBuffer()
+      ..writeln('# $title')
+      ..writeln()
+      ..writeln('Generated: `${generatedAt.toIso8601String()}`')
+      ..writeln()
+      ..writeln(baseline.toMarkdownLine('Baseline'))
+      ..writeln()
+      ..writeln(latest.toMarkdownLine('Latest'))
+      ..writeln()
+      ..writeln('Percentage improvement is mean parse-time reduction:')
+      ..writeln()
+      ..writeln('```text')
+      ..writeln('(baseline mean - latest mean) / baseline mean')
+      ..writeln('```')
+      ..writeln()
+      ..writeln('| Case | Baseline | Latest | Reduction | Speedup |')
+      ..writeln('| --- | ---: | ---: | ---: | ---: |');
+
+    for (final row in rows) {
+      buffer.writeln(
+        '| `${row.caseName}` | `${_formatMs(row.baselineMeanMicros)}` | '
+        '`${_formatMs(row.latestMeanMicros)}` | '
+        '`${_formatPercent(row.reductionPercent)}` | '
+        '`${_formatSpeedup(row.speedup)}` |',
+      );
+    }
+
+    buffer
+      ..writeln(
+        '| **Total** | `${_formatMs(total.baselineMeanMicros)}` | '
+        '`${_formatMs(total.latestMeanMicros)}` | '
+        '**`${_formatPercent(total.reductionPercent)}`** | '
+        '**`${_formatSpeedup(total.speedup)}`** |',
+      )
+      ..writeln();
+    return buffer.toString();
+  }
+}

--- a/pkgs/lualike/tool/parser_profile_compare.dart
+++ b/pkgs/lualike/tool/parser_profile_compare.dart
@@ -312,14 +312,12 @@ final class _Comparison {
       );
     }
 
-    buffer
-      ..writeln(
-        '| **Total** | `${_formatMs(total.baselineMeanMicros)}` | '
-        '`${_formatMs(total.latestMeanMicros)}` | '
-        '**`${_formatPercent(total.reductionPercent)}`** | '
-        '**`${_formatSpeedup(total.speedup)}`** |',
-      )
-      ..writeln();
+    buffer.writeln(
+      '| **Total** | `${_formatMs(total.baselineMeanMicros)}` | '
+      '`${_formatMs(total.latestMeanMicros)}` | '
+      '**`${_formatPercent(total.reductionPercent)}`** | '
+      '**`${_formatSpeedup(total.speedup)}`** |',
+    );
     return buffer.toString();
   }
 }

--- a/pkgs/lualike/tool/parser_profile_snapshot.dart
+++ b/pkgs/lualike/tool/parser_profile_snapshot.dart
@@ -1,0 +1,338 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:path/path.dart' as path;
+
+const _defaultBaselineRef = 'origin/ir';
+const _defaultOutputDirectory = 'benchmarks/parser_profiles';
+
+const _hotSuiteCases = [
+  'strings',
+  'test/api',
+  'test/files',
+  'test/math',
+  'test/db',
+  'test/locals',
+  'test/code',
+  'test/pm',
+  'test/strings',
+];
+
+Future<void> main(List<String> args) async {
+  final parser = ArgParser()
+    ..addOption(
+      'baseline-ref',
+      help: 'Git ref used for the clean baseline worktree.',
+      defaultsTo: _defaultBaselineRef,
+    )
+    ..addOption(
+      'output-dir',
+      help: 'Directory for generated local snapshots.',
+      defaultsTo: _defaultOutputDirectory,
+    )
+    ..addOption(
+      'warmup',
+      help: 'Warmup parses before measured runs.',
+      defaultsTo: '5',
+    )
+    ..addOption('repeat', help: 'Measured parses per script.', defaultsTo: '10')
+    ..addFlag(
+      'pub-get',
+      help: 'Run dart pub get in the temporary baseline worktree.',
+      defaultsTo: true,
+    )
+    ..addFlag(
+      'keep-baseline-worktree',
+      help: 'Leave the temporary baseline worktree on disk.',
+      defaultsTo: false,
+    )
+    ..addFlag('help', abbr: 'h', negatable: false, help: 'Print usage.');
+
+  final options = parser.parse(args);
+  if (options.flag('help')) {
+    stdout.writeln('Generate baseline/current parser profile snapshots.');
+    stdout.writeln(parser.usage);
+    return;
+  }
+
+  final packageRoot = _findPackageRoot();
+  final repoRoot = _gitOutput(packageRoot, ['rev-parse', '--show-toplevel']);
+  if (repoRoot == null) {
+    stderr.writeln('Could not find git repository root.');
+    exitCode = 1;
+    return;
+  }
+
+  final baselineRef = options.option('baseline-ref')!;
+  final warmup = _positiveInt(options.option('warmup')!, 'warmup');
+  final repeat = _positiveInt(options.option('repeat')!, 'repeat');
+  final outputDirectory = _resolvePackagePath(
+    packageRoot,
+    options.option('output-dir')!,
+  );
+  Directory(outputDirectory).createSync(recursive: true);
+
+  final stamp = _timestampForFile(DateTime.now());
+  final baselineWorktree = Directory.systemTemp.createTempSync(
+    'lualike-parser-baseline.',
+  );
+  final baselinePackageRoot = path.join(
+    baselineWorktree.path,
+    path.relative(packageRoot, from: repoRoot),
+  );
+
+  try {
+    _run('git', [
+      'worktree',
+      'add',
+      '--detach',
+      baselineWorktree.path,
+      baselineRef,
+    ], workingDirectory: repoRoot);
+    _copyProfilingTools(
+      currentPackageRoot: packageRoot,
+      baselinePackageRoot: baselinePackageRoot,
+    );
+
+    if (options.flag('pub-get')) {
+      _run('dart', ['pub', 'get'], workingDirectory: baselinePackageRoot);
+    }
+
+    final small = _ProfileSet(
+      name: 'small-parser-corpus',
+      title: 'Small Parser Corpus',
+      baselineJson: path.join(outputDirectory, '$stamp-baseline-small.json'),
+      latestJson: path.join(outputDirectory, '$stamp-latest-small.json'),
+      comparisonJson: path.join(
+        outputDirectory,
+        '$stamp-comparison-small.json',
+      ),
+      comparisonMarkdown: path.join(
+        outputDirectory,
+        '$stamp-comparison-small.md',
+      ),
+      profileArguments: const [],
+    );
+    final hot = _ProfileSet(
+      name: 'hot-lua-suite',
+      title: 'Hot Lua Suite',
+      baselineJson: path.join(outputDirectory, '$stamp-baseline-hot.json'),
+      latestJson: path.join(outputDirectory, '$stamp-latest-hot.json'),
+      comparisonJson: path.join(outputDirectory, '$stamp-comparison-hot.json'),
+      comparisonMarkdown: path.join(
+        outputDirectory,
+        '$stamp-comparison-hot.md',
+      ),
+      profileArguments: [
+        for (final caseName in _hotSuiteCases) ...['-c', caseName],
+        '--corpus=luascripts',
+      ],
+    );
+
+    for (final set in [small, hot]) {
+      _runProfileSet(
+        set: set,
+        baselinePackageRoot: baselinePackageRoot,
+        currentPackageRoot: packageRoot,
+        baselineRef: baselineRef,
+        warmup: warmup,
+        repeat: repeat,
+      );
+    }
+
+    stdout.writeln('');
+    stdout.writeln('Generated parser profile snapshots:');
+    for (final set in [small, hot]) {
+      stdout.writeln('  ${set.name}');
+      stdout.writeln('    baseline: ${set.baselineJson}');
+      stdout.writeln('    latest:   ${set.latestJson}');
+      stdout.writeln('    summary:  ${set.comparisonMarkdown}');
+      stdout.writeln('    json:     ${set.comparisonJson}');
+    }
+  } finally {
+    if (options.flag('keep-baseline-worktree')) {
+      stdout.writeln('Kept baseline worktree: ${baselineWorktree.path}');
+    } else {
+      _run('git', [
+        'worktree',
+        'remove',
+        '--force',
+        baselineWorktree.path,
+      ], workingDirectory: repoRoot);
+    }
+  }
+}
+
+void _runProfileSet({
+  required _ProfileSet set,
+  required String baselinePackageRoot,
+  required String currentPackageRoot,
+  required String baselineRef,
+  required int warmup,
+  required int repeat,
+}) {
+  _run('dart', [
+    'run',
+    'tool/parser_profile.dart',
+    '--warmup=$warmup',
+    '--repeat=$repeat',
+    '--label=$baselineRef ${set.name}',
+    '--json-out=${set.baselineJson}',
+    '--no-fail-fast',
+    ...set.profileArguments,
+  ], workingDirectory: baselinePackageRoot);
+  _run('dart', [
+    'run',
+    'tool/parser_profile.dart',
+    '--warmup=$warmup',
+    '--repeat=$repeat',
+    '--label=current ${set.name}',
+    '--json-out=${set.latestJson}',
+    '--no-fail-fast',
+    ...set.profileArguments,
+  ], workingDirectory: currentPackageRoot);
+  _run('dart', [
+    'run',
+    'tool/parser_profile_compare.dart',
+    '--baseline=${set.baselineJson}',
+    '--latest=${set.latestJson}',
+    '--title=${set.title}',
+    '--json-out=${set.comparisonJson}',
+    '--markdown-out=${set.comparisonMarkdown}',
+  ], workingDirectory: currentPackageRoot);
+}
+
+void _copyProfilingTools({
+  required String currentPackageRoot,
+  required String baselinePackageRoot,
+}) {
+  for (final relativePath in [
+    'tool/parser_profile.dart',
+    'tool/parser_profile_compare.dart',
+  ]) {
+    final source = File(path.join(currentPackageRoot, relativePath));
+    final destination = File(path.join(baselinePackageRoot, relativePath));
+    destination.parent.createSync(recursive: true);
+    source.copySync(destination.path);
+  }
+
+  final sourceCorpus = Directory(
+    path.join(currentPackageRoot, 'luascripts/parser_profiles'),
+  );
+  final destinationCorpus = Directory(
+    path.join(baselinePackageRoot, 'luascripts/parser_profiles'),
+  );
+  destinationCorpus.createSync(recursive: true);
+  for (final entry in sourceCorpus.listSync(recursive: true)) {
+    if (entry is! File || !entry.path.endsWith('.lua')) {
+      continue;
+    }
+    final relativePath = path.relative(entry.path, from: sourceCorpus.path);
+    final destination = File(path.join(destinationCorpus.path, relativePath));
+    destination.parent.createSync(recursive: true);
+    entry.copySync(destination.path);
+  }
+}
+
+String _findPackageRoot() {
+  var current = path.normalize(Directory.current.absolute.path);
+  while (true) {
+    final pubspec = File(path.join(current, 'pubspec.yaml'));
+    final tool = File(path.join(current, 'tool', 'parser_profile.dart'));
+    if (pubspec.existsSync() && tool.existsSync()) {
+      return current;
+    }
+
+    final nestedPackage = path.join(current, 'pkgs', 'lualike');
+    final nestedPubspec = File(path.join(nestedPackage, 'pubspec.yaml'));
+    final nestedTool = File(
+      path.join(nestedPackage, 'tool', 'parser_profile.dart'),
+    );
+    if (nestedPubspec.existsSync() && nestedTool.existsSync()) {
+      return nestedPackage;
+    }
+
+    final parent = path.dirname(current);
+    if (parent == current) {
+      throw StateError('Could not find the lualike package root.');
+    }
+    current = parent;
+  }
+}
+
+String _resolvePackagePath(String packageRoot, String filePath) {
+  return path.normalize(
+    path.isAbsolute(filePath) ? filePath : path.join(packageRoot, filePath),
+  );
+}
+
+String _timestampForFile(DateTime dateTime) {
+  final local = dateTime.toIso8601String().split('.').first;
+  return local.replaceAll(':', '-');
+}
+
+int _positiveInt(String value, String name) {
+  final parsed = int.tryParse(value);
+  if (parsed == null || parsed <= 0) {
+    throw ArgumentError.value(value, name, 'Expected a positive integer');
+  }
+  return parsed;
+}
+
+String? _gitOutput(String workingDirectory, List<String> arguments) {
+  final result = Process.runSync(
+    'git',
+    arguments,
+    workingDirectory: workingDirectory,
+  );
+  if (result.exitCode != 0) {
+    return null;
+  }
+  return (result.stdout as String).trim();
+}
+
+void _run(
+  String executable,
+  List<String> arguments, {
+  required String workingDirectory,
+}) {
+  stdout.writeln(
+    '[${path.basename(workingDirectory)}] '
+    '$executable ${arguments.join(' ')}',
+  );
+  final result = Process.runSync(
+    executable,
+    arguments,
+    workingDirectory: workingDirectory,
+  );
+  stdout.write(result.stdout);
+  stderr.write(result.stderr);
+  if (result.exitCode != 0) {
+    throw ProcessException(
+      executable,
+      arguments,
+      'Command failed with exit code ${result.exitCode}',
+      result.exitCode,
+    );
+  }
+}
+
+final class _ProfileSet {
+  const _ProfileSet({
+    required this.name,
+    required this.title,
+    required this.baselineJson,
+    required this.latestJson,
+    required this.comparisonJson,
+    required this.comparisonMarkdown,
+    required this.profileArguments,
+  });
+
+  final String name;
+  final String title;
+  final String baselineJson;
+  final String latestJson;
+  final String comparisonJson;
+  final String comparisonMarkdown;
+  final List<String> profileArguments;
+}

--- a/pkgs/lualike/tool/scenario_bench.dart
+++ b/pkgs/lualike/tool/scenario_bench.dart
@@ -57,6 +57,11 @@ const _groupScenarios = <String, List<String>>{
     'format-string-complex',
     'format-string-mixed',
   ],
+  'lua-string-parser-all': <String>[
+    'lua-string-parser-simple',
+    'lua-string-parser-escaped',
+    'lua-string-parser-byte',
+  ],
 };
 
 final _leafScenarios = <String>{
@@ -83,6 +88,9 @@ final _leafScenarios = <String>{
   'format-string-simple',
   'format-string-complex',
   'format-string-mixed',
+  'lua-string-parser-simple',
+  'lua-string-parser-escaped',
+  'lua-string-parser-byte',
 };
 
 final List<String> _scenarioNames = (<String>{
@@ -510,6 +518,36 @@ assert(n > 0)
       workUnits: 40000,
     ),
     'format-string-mixed' => _formatStringMixedScenario(),
+    'lua-string-parser-simple' => _luaStringParserScenario(
+      name: 'lua-string-parser-simple',
+      content: 'plain ascii text with numbers 12345 and punctuation !?',
+      workUnits: 40000,
+    ),
+    'lua-string-parser-escaped' => _luaStringParserScenario(
+      name: 'lua-string-parser-escaped',
+      content:
+          r'line\n tab\t byte\123 hex\x41 unicode\u{1f600} quote\" slash\\ z\z   '
+          '\nnext',
+      workUnits: 40000,
+    ),
+    'lua-string-parser-byte' => _luaStringParserScenario(
+      name: 'lua-string-parser-byte',
+      content: String.fromCharCodes(<int>[
+        0xE1,
+        0x6C,
+        0x6F,
+        0x5C,
+        0x78,
+        0x34,
+        0x31,
+        0x5C,
+        0x32,
+        0x35,
+        0x35,
+      ]),
+      sourceCodeUnitsAreBytes: true,
+      workUnits: 40000,
+    ),
     _ => throw ArgumentError.value(name, 'scenario', 'Unknown benchmark'),
   };
 }
@@ -679,6 +717,31 @@ _BenchScenario _formatStringMixedScenario() {
       var total = 0;
       for (var i = 0; i < workUnits; i++) {
         total += FormatStringParser.parse(formats[i % formats.length]).length;
+      }
+      if (total == 0) {
+        throw StateError('unexpected zero total');
+      }
+    },
+  );
+}
+
+_BenchScenario _luaStringParserScenario({
+  required String name,
+  required String content,
+  required int workUnits,
+  bool sourceCodeUnitsAreBytes = false,
+}) {
+  return _BenchScenario(
+    name: name,
+    workUnits: workUnits,
+    workLabel: 'string parses',
+    run: (_) async {
+      var total = 0;
+      for (var i = 0; i < workUnits; i++) {
+        total += LuaStringParser.parseStringContent(
+          content,
+          sourceCodeUnitsAreBytes: sourceCodeUnitsAreBytes,
+        ).length;
       }
       if (total == 0) {
         throw StateError('unexpected zero total');

--- a/pkgs/lualike/tool/scenario_bench.dart
+++ b/pkgs/lualike/tool/scenario_bench.dart
@@ -52,6 +52,11 @@ const _groupScenarios = <String, List<String>>{
     'binary-format-unpack',
     'binary-format-mixed',
   ],
+  'format-string-all': <String>[
+    'format-string-simple',
+    'format-string-complex',
+    'format-string-mixed',
+  ],
 };
 
 final _leafScenarios = <String>{
@@ -75,6 +80,9 @@ final _leafScenarios = <String>{
   'binary-format-pack',
   'binary-format-unpack',
   'binary-format-mixed',
+  'format-string-simple',
+  'format-string-complex',
+  'format-string-mixed',
 };
 
 final List<String> _scenarioNames = (<String>{
@@ -491,6 +499,17 @@ assert(n > 0)
       format: '<!8I2I4I8c32zxxXf',
       workUnits: 40000,
     ),
+    'format-string-simple' => _formatStringScenario(
+      name: 'format-string-simple',
+      format: 'value=%d',
+      workUnits: 40000,
+    ),
+    'format-string-complex' => _formatStringScenario(
+      name: 'format-string-complex',
+      format: 'id=%08X name=%-20.12s score=%+10.3f raw=%q %% done',
+      workUnits: 40000,
+    ),
+    'format-string-mixed' => _formatStringMixedScenario(),
     _ => throw ArgumentError.value(name, 'scenario', 'Unknown benchmark'),
   };
 }
@@ -614,6 +633,52 @@ _BenchScenario _binaryFormatScenario({
       var total = 0;
       for (var i = 0; i < workUnits; i++) {
         total += BinaryFormatParser.parse(format).length;
+      }
+      if (total == 0) {
+        throw StateError('unexpected zero total');
+      }
+    },
+  );
+}
+
+_BenchScenario _formatStringScenario({
+  required String name,
+  required String format,
+  required int workUnits,
+}) {
+  return _BenchScenario(
+    name: name,
+    workUnits: workUnits,
+    workLabel: 'format parses',
+    run: (_) async {
+      var total = 0;
+      for (var i = 0; i < workUnits; i++) {
+        total += FormatStringParser.parse(format).length;
+      }
+      if (total == 0) {
+        throw StateError('unexpected zero total');
+      }
+    },
+  );
+}
+
+_BenchScenario _formatStringMixedScenario() {
+  const formats = <String>[
+    '%d',
+    'literal only',
+    'name=%s age=%03d',
+    'x=%#08x y=%-10.4f z=%q',
+    '%% %c %i %u %o %a %A %p',
+  ];
+  const workUnits = 50000;
+  return _BenchScenario(
+    name: 'format-string-mixed',
+    workUnits: workUnits,
+    workLabel: 'format parses',
+    run: (_) async {
+      var total = 0;
+      for (var i = 0; i < workUnits; i++) {
+        total += FormatStringParser.parse(formats[i % formats.length]).length;
       }
       if (total == 0) {
         throw StateError('unexpected zero total');

--- a/pkgs/lualike/tool/scenario_bench.dart
+++ b/pkgs/lualike/tool/scenario_bench.dart
@@ -62,6 +62,11 @@ const _groupScenarios = <String, List<String>>{
     'lua-string-parser-escaped',
     'lua-string-parser-byte',
   ],
+  'lua-pattern-all': <String>[
+    'lua-pattern-compile-literal',
+    'lua-pattern-compile-class',
+    'lua-pattern-match-literal',
+  ],
 };
 
 final _leafScenarios = <String>{
@@ -91,6 +96,9 @@ final _leafScenarios = <String>{
   'lua-string-parser-simple',
   'lua-string-parser-escaped',
   'lua-string-parser-byte',
+  'lua-pattern-compile-literal',
+  'lua-pattern-compile-class',
+  'lua-pattern-match-literal',
 };
 
 final List<String> _scenarioNames = (<String>{
@@ -548,6 +556,29 @@ assert(n > 0)
       sourceCodeUnitsAreBytes: true,
       workUnits: 40000,
     ),
+    'lua-pattern-compile-literal' => _luaPatternCompileScenario(
+      name: 'lua-pattern-compile-literal',
+      patterns: const <String>[
+        'needle',
+        'status',
+        'function',
+        'return',
+        'table',
+      ],
+      workUnits: 50000,
+    ),
+    'lua-pattern-compile-class' => _luaPatternCompileScenario(
+      name: 'lua-pattern-compile-class',
+      patterns: const <String>[
+        r'%w+',
+        r'(%a+)%s+(%d+)',
+        r'^%s*(.-)%s*$',
+        r'%f[%a]%w+',
+        r'[%w_]+',
+      ],
+      workUnits: 20000,
+    ),
+    'lua-pattern-match-literal' => _luaPatternMatchLiteralScenario(),
     _ => throw ArgumentError.value(name, 'scenario', 'Unknown benchmark'),
   };
 }
@@ -742,6 +773,49 @@ _BenchScenario _luaStringParserScenario({
           content,
           sourceCodeUnitsAreBytes: sourceCodeUnitsAreBytes,
         ).length;
+      }
+      if (total == 0) {
+        throw StateError('unexpected zero total');
+      }
+    },
+  );
+}
+
+_BenchScenario _luaPatternCompileScenario({
+  required String name,
+  required List<String> patterns,
+  required int workUnits,
+}) {
+  return _BenchScenario(
+    name: name,
+    workUnits: workUnits,
+    workLabel: 'pattern compiles',
+    run: (_) async {
+      var total = 0;
+      for (var i = 0; i < workUnits; i++) {
+        final pattern = LuaPattern.compile(patterns[i % patterns.length]);
+        final match = pattern.firstMatch(patterns[i % patterns.length]);
+        total += match?.end ?? 0;
+      }
+      if (total == 0) {
+        throw StateError('unexpected zero total');
+      }
+    },
+  );
+}
+
+_BenchScenario _luaPatternMatchLiteralScenario() {
+  const workUnits = 60000;
+  final subject = '${'abcd '.padRight(1024, 'x')} needle tail';
+  final pattern = LuaPattern.compile('needle');
+  return _BenchScenario(
+    name: 'lua-pattern-match-literal',
+    workUnits: workUnits,
+    workLabel: 'pattern matches',
+    run: (_) async {
+      var total = 0;
+      for (var i = 0; i < workUnits; i++) {
+        total += pattern.firstMatch(subject)?.start ?? 0;
       }
       if (total == 0) {
         throw StateError('unexpected zero total');

--- a/pkgs/lualike/tool/scenario_bench.dart
+++ b/pkgs/lualike/tool/scenario_bench.dart
@@ -67,6 +67,7 @@ const _groupScenarios = <String, List<String>>{
     'lua-pattern-compile-class',
     'lua-pattern-match-literal',
   ],
+  'ir-reader-all': <String>['ir-reader-small', 'ir-reader-instructions'],
 };
 
 final _leafScenarios = <String>{
@@ -99,6 +100,8 @@ final _leafScenarios = <String>{
   'lua-pattern-compile-literal',
   'lua-pattern-compile-class',
   'lua-pattern-match-literal',
+  'ir-reader-small',
+  'ir-reader-instructions',
 };
 
 final List<String> _scenarioNames = (<String>{
@@ -579,6 +582,16 @@ assert(n > 0)
       workUnits: 20000,
     ),
     'lua-pattern-match-literal' => _luaPatternMatchLiteralScenario(),
+    'ir-reader-small' => _irReaderScenario(
+      name: 'ir-reader-small',
+      source: _smallIrReaderSource,
+      workUnits: 2000,
+    ),
+    'ir-reader-instructions' => _irReaderScenario(
+      name: 'ir-reader-instructions',
+      source: _instructionHeavyIrReaderSource(),
+      workUnits: 400,
+    ),
     _ => throw ArgumentError.value(name, 'scenario', 'Unknown benchmark'),
   };
 }
@@ -822,6 +835,95 @@ _BenchScenario _luaPatternMatchLiteralScenario() {
       }
     },
   );
+}
+
+_BenchScenario _irReaderScenario({
+  required String name,
+  required String source,
+  required int workUnits,
+}) {
+  return _BenchScenario(
+    name: name,
+    workUnits: workUnits,
+    workLabel: 'IR parses',
+    run: (_) async {
+      var total = 0;
+      for (var i = 0; i < workUnits; i++) {
+        total += LualikeIrReader.parse(
+          source,
+        ).mainPrototype.instructions.length;
+      }
+      if (total == 0) {
+        throw StateError('unexpected zero total');
+      }
+    },
+  );
+}
+
+const _smallIrReaderSource = '''
+chunk has_debug_info=true {
+  prototype main register_count=1 param_count=0 is_vararg=true {
+    constants {
+      int 42;
+    }
+    instructions {
+      // pc=0 line=1
+      abc VARARGPREP a=0 b=0 c=0;
+      // pc=1 line=2
+      abx LOADK a=0 bx=0;
+      // pc=2 line=2
+      abc RETURN1 a=0 b=0 c=0;
+    }
+    debug_info {
+      line_info [1, 2, 2];
+      preferred_name "main";
+      preferred_name_what "global";
+    }
+  }
+}
+''';
+
+String _instructionHeavyIrReaderSource() {
+  final buffer = StringBuffer()
+    ..writeln('chunk has_debug_info=true has_constant_hash=true {')
+    ..writeln(
+      '  prototype main register_count=4 param_count=0 is_vararg=true {',
+    )
+    ..writeln('    constants {')
+    ..writeln('      int 1;')
+    ..writeln('      int 2;')
+    ..writeln('      short "value";')
+    ..writeln('    }')
+    ..writeln('    instructions {')
+    ..writeln('      abc VARARGPREP a=0 b=0 c=0;');
+  for (var index = 0; index < 96; index++) {
+    buffer
+      ..writeln('      // pc=$index line=${index + 1}')
+      ..writeln('      abx LOADK a=${index % 3} bx=${index % 2};')
+      ..writeln('      abc MOVE a=${(index + 1) % 3} b=${index % 3} c=0;');
+  }
+  buffer
+    ..writeln('      abc RETURN1 a=0 b=0 c=0;')
+    ..writeln('    }')
+    ..writeln('    debug_info {')
+    ..write('      line_info [');
+  for (var index = 0; index < 194; index++) {
+    if (index > 0) {
+      buffer.write(', ');
+    }
+    buffer.write(index + 1);
+  }
+  buffer
+    ..writeln('];')
+    ..writeln('      preferred_name "main";')
+    ..writeln('      preferred_name_what "global";')
+    ..writeln('      local_names {')
+    ..writeln('        local name="tmp" start_pc=1 end_pc=10 register=0;')
+    ..writeln('      }')
+    ..writeln('    }')
+    ..writeln('  }')
+    ..writeln('}');
+  return buffer.toString();
 }
 
 void _runPetitParserProfile(_ParserProfileSpec spec, {required int top}) {


### PR DESCRIPTION
## Summary
- add scanner-backed fast paths for Lua trivia, tokens, identifiers, literals, expressions, and expression statements
- dispatch Lua statements by prefix to avoid the long failed keyword-parser chain on common statements
- dispatch Lua call arguments by first token instead of using the generic args choice parser
- parse prefix-expression suffix chains directly instead of allocating suffix lists through combinators
- skip impossible prefix-suffix probes before invoking the suffix parser
- streamline function parameter-list parsing with a custom parser
- tighten the common trivia-skipping path used by token parsing
- replace the combinator-based AST span wrapper with a custom parser wrapper
- cache token parser failure messages to avoid rebuilding the same strings on failed probes
- scan Lua number literals directly while preserving decimal and hexadecimal forms
- scan power-expression `^` tails directly while preserving right associativity
- scan binary string-pack format strings directly while preserving the exported parser pieces
- parse binary format numeric sizes without BigInt on the hot path
- scan string.format format strings directly while preserving the exported parser pieces
- scan Lua string literal content directly while keeping `LuaStringParser.build()` available
- fast-path literal Lua patterns and tighten pattern compiler character classification
- scan textual IR whitespace/comments directly for faster token trimming
- specialize textual IR string tokens and integer literals
- cache string parsing helpers and avoid reparsing simple string bytes
- add parser profiling corpus plus JSON, comparison, and baseline/current snapshot tooling
- add direct scenario benchmarks for binary, string-format, Lua string-content, Lua pattern, and textual IR parser hot paths
- commit generated baseline/latest profile snapshots for the small parser corpus and hot Lua suite

## Validation
- dart analyze tool/parser_profile.dart tool/parser_profile_compare.dart tool/parser_profile_snapshot.dart
- dart analyze lib/src/parsers/lua.dart
- dart analyze lib/src/parsers/lua.dart test/parsers/number_literal_test.dart tool/scenario_bench.dart
- dart test test/parsers test/interpreter/expressions/table_assignment_test.dart test/interop/table_access/table_indexing_test.dart test/ir/compiler_table_assignment_test.dart test/ir/vm_table_assignment_test.dart (79/79 passed)
- dart analyze lib/src/parsers/binary_format.dart
- dart analyze lib/src/parsers/binary_format.dart && dart test test/parsers/binary_format_test.dart (31/31 passed)
- dart analyze lib/src/parsers/format.dart tool/scenario_bench.dart
- dart analyze lib/src/parsers/string.dart
- dart analyze lib/src/parsers/pattern.dart tool/scenario_bench.dart
- dart analyze lib/src/parsers/ir_reader.dart tool/scenario_bench.dart
- dart run tool/parser_profile_snapshot.dart --warmup=1 --repeat=1
- dart run tool/parser_profile_snapshot.dart
- dart run tool/scenario_bench.dart --scenario=parse-all --warmup=5 --repeat=20
- dart run tool/scenario_bench.dart --scenario=ir-reader-all --warmup=3 --repeat=10
- dart test test/parsers test/ir/compiler_close_test.dart test/ir/vm_const_test.dart (66/66 passed)
- dart test test/parsers (60/60 passed)
- dart test test/parsers test/ir/compiler_arithmetic_test.dart test/ir/vm_arithmetic_test.dart test/interop/number_test.dart (110/110 passed)
- dart test test/parsers/binary_format_test.dart (31/31 passed)
- dart test test/stdlib/format_parser_test.dart (19/19 passed)
- dart test test/stdlib/string_format_test.dart test/stdlib/string_test.dart (76/76 passed)
- dart test test/parsers/string_literal_regression_test.dart test/stdlib/string_regression_test.dart test/stdlib/utf8_test.dart (62/62 passed)
- dart test test/lua_pattern_compiler_test.dart test/pm (64/64 passed)
- dart test test/stdlib/string_test.dart test/stdlib/utf8_test.dart (103/103 passed)
- dart test test/parsers/ir_reader_test.dart test/ir/textual_lowering_test.dart (5/5 passed)
- dart run tool/test.dart --compile-runner && ./test_runner (30/30 passed, total time 65080ms)

## Snapshot Totals
Fresh snapshot set: `benchmarks/parser_profiles/2026-05-03T11-01-01-*`, baseline `origin/ir` at `3f906999`, Lua parser snapshot code `a6d79f1e`.

- Small parser corpus: 68.3% mean-time reduction, 3.2x speedup
- Hot Lua suite: 97.8% mean-time reduction, 45.5x speedup

## Additional Targeted Comparisons
- Function parameter-list parser: 119.450 ms -> 107.446 ms on the hot subset, 10.0% reduction, 1.11x speedup
- Trivia skip fast path: 70.937 ms -> 60.993 ms on the hot subset with `--repeat=20`, 14.0% reduction, 1.16x speedup
- Span wrapper parser: 155.517 ms -> 82.474 ms on the hot subset with `--repeat=20`, 47.0% reduction, 1.89x speedup
- Token failure message cache: 93.032 ms -> 78.054 ms on the hot subset with `--repeat=20`, 16.1% reduction, 1.19x speedup
- Lua number literal parser, parse-all total: 53.51 ms -> 39.84 ms with `--scenario=parse-all --warmup=5 --repeat=20`, 25.5% reduction, 1.34x speedup
- Lua number literal parser, parse-calls: 10.20 ms -> 8.79 ms, 13.8% reduction, 1.16x speedup
- Lua number literal parser, parse-sort: 6.17 ms -> 5.97 ms, 3.2% reduction, 1.03x speedup
- Lua number literal parser, parse-math: 15.07 ms -> 11.28 ms, 25.1% reduction, 1.34x speedup
- Lua number literal parser, parse-constructs: 8.85 ms -> 5.27 ms, 40.5% reduction, 1.68x speedup
- Lua number literal parser, parse-nextvar: 13.22 ms -> 8.53 ms, 35.5% reduction, 1.55x speedup
- Power-expression tail parser, parse-all total: 44.10 ms -> 38.38 ms with `--scenario=parse-all --warmup=5 --repeat=20`, 13.0% reduction, 1.15x speedup
- Power-expression tail parser, parse-calls: 10.77 ms -> 10.59 ms, 1.7% reduction, 1.02x speedup
- Power-expression tail parser, parse-sort: 4.51 ms -> 4.62 ms, 2.4% regression, 0.98x speedup
- Power-expression tail parser, parse-math: 12.84 ms -> 10.85 ms, 15.5% reduction, 1.18x speedup
- Power-expression tail parser, parse-constructs: 6.39 ms -> 4.85 ms, 24.1% reduction, 1.32x speedup
- Power-expression tail parser, parse-nextvar: 9.59 ms -> 7.47 ms, 22.1% reduction, 1.28x speedup
- Statement prefix dispatcher, parse-all total: 48.48 ms -> 35.56 ms with `--scenario=parse-all --warmup=5 --repeat=20`, 26.7% reduction, 1.36x speedup
- Statement prefix dispatcher, parse-calls: 14.72 ms -> 9.10 ms, 38.2% reduction, 1.62x speedup
- Statement prefix dispatcher, parse-sort: 4.65 ms -> 4.39 ms, 5.6% reduction, 1.06x speedup
- Statement prefix dispatcher, parse-math: 12.73 ms -> 11.11 ms, 12.7% reduction, 1.15x speedup
- Statement prefix dispatcher, parse-constructs: 6.14 ms -> 4.58 ms, 25.4% reduction, 1.34x speedup
- Statement prefix dispatcher, parse-nextvar: 10.24 ms -> 6.38 ms, 37.7% reduction, 1.61x speedup
- Call args dispatcher, parse-all total: 41.20 ms -> 27.14 ms with `--scenario=parse-all --warmup=5 --repeat=20`, 34.1% reduction, 1.52x speedup
- Call args dispatcher, parse-calls: 10.58 ms -> 7.71 ms, 27.1% reduction, 1.37x speedup
- Call args dispatcher, parse-sort: 4.97 ms -> 3.22 ms, 35.2% reduction, 1.54x speedup
- Call args dispatcher, parse-math: 12.12 ms -> 7.63 ms, 37.0% reduction, 1.59x speedup
- Call args dispatcher, parse-constructs: 4.07 ms -> 3.69 ms, 9.3% reduction, 1.10x speedup
- Call args dispatcher, parse-nextvar: 9.46 ms -> 4.89 ms, 48.3% reduction, 1.93x speedup
- Prefix suffix parser, parse-all total: 25.73 ms -> 22.85 ms with `--scenario=parse-all --warmup=10 --repeat=50`, 11.2% reduction, 1.13x speedup
- Prefix suffix parser, parse-calls: 5.54 ms -> 5.77 ms, 4.2% regression, 0.96x speedup
- Prefix suffix parser, parse-sort: 3.68 ms -> 2.48 ms, 32.6% reduction, 1.48x speedup
- Prefix suffix parser, parse-math: 7.75 ms -> 6.77 ms, 12.6% reduction, 1.14x speedup
- Prefix suffix parser, parse-constructs: 3.16 ms -> 2.45 ms, 22.5% reduction, 1.29x speedup
- Prefix suffix parser, parse-nextvar: 5.60 ms -> 5.38 ms, 3.9% reduction, 1.04x speedup
- Prefix suffix-start guard, parse-all total: 23.02 ms -> 21.99 ms with `--scenario=parse-all --warmup=10 --repeat=50`, 4.5% reduction, 1.05x speedup
- Prefix suffix-start guard, parse-calls: 4.94 ms -> 4.63 ms, 6.3% reduction, 1.07x speedup
- Prefix suffix-start guard, parse-sort: 3.09 ms -> 2.41 ms, 22.0% reduction, 1.28x speedup
- Prefix suffix-start guard, parse-math: 6.52 ms -> 7.36 ms, 12.9% regression, 0.89x speedup
- Prefix suffix-start guard, parse-constructs: 2.37 ms -> 2.89 ms, 21.9% regression, 0.82x speedup
- Prefix suffix-start guard, parse-nextvar: 6.10 ms -> 4.70 ms, 23.0% reduction, 1.30x speedup
- Binary format parser, pack scenario: 325.87 ms -> 186.12 ms with `--scenario=binary-format-all --warmup=3 --repeat=10`, 42.9% reduction, throughput 122748/s -> 214909/s
- Binary format parser, unpack scenario: 207.24 ms -> 165.69 ms with `--scenario=binary-format-all --warmup=3 --repeat=10`, 20.1% reduction, throughput 193009/s -> 241415/s
- Binary format parser, mixed scenario: 518.23 ms -> 285.47 ms with `--scenario=binary-format-all --warmup=3 --repeat=10`, 44.9% reduction, throughput 77186/s -> 140119/s
- Binary format size parser, all total: 361.38 ms -> 162.70 ms with `--scenario=binary-format-all --warmup=3 --repeat=10`, 55.0% reduction, 2.22x speedup
- Binary format size parser, pack scenario: 109.33 ms -> 36.56 ms, 66.6% reduction, throughput 365864/s -> 1094068/s
- Binary format size parser, unpack scenario: 103.40 ms -> 32.40 ms, 68.7% reduction, throughput 386866/s -> 1234697/s
- Binary format size parser, mixed scenario: 148.65 ms -> 93.74 ms, 36.9% reduction, throughput 269086/s -> 426722/s
- Format string parser, simple scenario: 620.19 ms -> 5.54 ms with `--scenario=format-string-all --warmup=3 --repeat=10`, 99.1% reduction, throughput 64496/s -> 7214487/s
- Format string parser, complex scenario: 930.44 ms -> 47.27 ms with `--scenario=format-string-all --warmup=3 --repeat=10`, 94.9% reduction, throughput 42991/s -> 846131/s
- Format string parser, mixed scenario: 909.38 ms -> 28.64 ms with `--scenario=format-string-all --warmup=3 --repeat=10`, 96.9% reduction, throughput 54982/s -> 1745798/s
- Lua string-content parser, simple scenario: 512.56 ms -> 43.40 ms with `--scenario=lua-string-parser-all --warmup=3 --repeat=10`, 91.5% reduction, throughput 78040/s -> 921614/s
- Lua string-content parser, escaped scenario: 2516.75 ms -> 63.71 ms with `--scenario=lua-string-parser-all --warmup=3 --repeat=10`, 97.5% reduction, throughput 15893/s -> 627813/s
- Lua string-content parser, byte scenario: 590.48 ms -> 12.46 ms with `--scenario=lua-string-parser-all --warmup=3 --repeat=10`, 97.9% reduction, throughput 67742/s -> 3210737/s
- Lua pattern parser, literal compile scenario: 186.18 ms -> 9.39 ms with `--scenario=lua-pattern-all --warmup=3 --repeat=10`, 95.0% reduction, throughput 268558/s -> 5322603/s
- Lua pattern parser, class compile scenario: 124.59 ms -> 118.15 ms with `--scenario=lua-pattern-all --warmup=3 --repeat=10`, 5.2% reduction, throughput 160528/s -> 169283/s
- Lua pattern parser, literal match scenario: 3791.61 ms -> 696.41 ms with `--scenario=lua-pattern-all --warmup=3 --repeat=10`, 81.6% reduction, throughput 15824/s -> 86156/s
- Textual IR reader, small scenario: 326.93 ms -> 135.82 ms with `--scenario=ir-reader-all --warmup=3 --repeat=10`, 58.5% reduction, 2.41x speedup, throughput 6117/s -> 14725/s
- Textual IR reader, instruction-heavy scenario: 1742.96 ms -> 753.30 ms with `--scenario=ir-reader-all --warmup=3 --repeat=10`, 56.8% reduction, 2.31x speedup, throughput 229/s -> 531/s



